### PR TITLE
feat: add CI validation for docs and skills

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,38 @@
+name: Validate Docs & Skills
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "skills/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate docs
+        run: python scripts/validate_docs.py
+
+      - name: Validate skills
+        run: python scripts/validate_skills.py
+
+  auto-merge:
+    needs: validate
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable auto-merge
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 Both LLM and Data layers use the same pattern: adapters register capabilities,
 registry routes requests by capability. Agents never reference a specific source directly.
 
-```
+```text
 Agent: "I need Price data for AAPL"
   → Registry.get(Price)
   → Returns FinnhubAdapter (primary) or YfinanceAdapter (fallback)
@@ -52,7 +52,7 @@ API key missing → adapter auto-skipped. Fallback kicks in transparently.
 
 DuckDB single-file database (`tracer.db`). Append-only for market data, analytical queries optimized.
 
-```
+```text
 DuckDB (tracer.db)
 ├── prices             - OHLCV time series (daily append)
 ├── fundamentals       - valuation, financial statements (quarterly append)

--- a/docs/contrib/docs-rules.md
+++ b/docs/contrib/docs-rules.md
@@ -16,7 +16,7 @@ Every doc file must have:
 
 ## Links
 
-- All internal links (e.g., `[see architecture](architecture.md)`) must point to existing files.
+- All internal links must point to existing files. Example: `[see architecture](../architecture.md)`
 - No absolute paths to local filesystem. Use relative paths only.
 - References to AGENTS.md sections must match actual section headings.
 

--- a/docs/contrib/skills-rules.md
+++ b/docs/contrib/skills-rules.md
@@ -6,7 +6,7 @@ Validation rules for files under `skills/`.
 
 Every skill must be a directory containing at least `SKILL.md`:
 
-```
+```text
 skills/
 └── {skill-name}/
     └── SKILL.md

--- a/docs/conversational-layer.md
+++ b/docs/conversational-layer.md
@@ -2,7 +2,7 @@
 
 Users interact with Tracer via natural language queries. The conversational layer wraps the Tracer Cycle steps as discrete tools, manages session context, and routes each query to the appropriate pipeline steps.
 
-```
+```text
 CLI (REPL)
     ↓
 ConversationEngine          — in-memory turn history, context window management
@@ -70,7 +70,7 @@ Failed tools are excluded from the evidence chain and flagged in the response ca
 
 ## Response Format
 
-```
+```text
 [ANALYSIS: {ticker/theme} — {date}]
 Conviction: {score}/10
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,6 +1,6 @@
 # Agent Pipeline (Tracer Cycle)
 
-```
+```text
 Screening → Macro Regime → Cross-Market Discovery → Consensus Mapping
     → Contrarian Detection → Conviction Scoring → Alpha Report
 ```

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -2,7 +2,7 @@
 
 Agent configuration lives at `~/.tracer/`, loaded at session start.
 
-```
+```text
 ~/.tracer/
 ├── IDENTITY.md      # Agent role and identity
 ├── SOUL.md          # Tone: cold, data-first, adversarial self-check

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -1,0 +1,79 @@
+"""Validate docs/ files against docs/contrib/docs-rules.md."""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = ROOT / "docs"
+ERRORS: list[str] = []
+
+
+def error(file: Path, msg: str) -> None:
+    rel = file.relative_to(ROOT)
+    ERRORS.append(f"{rel}: {msg}")
+
+
+def check_filename(file: Path) -> None:
+    if file.name != file.name.lower():
+        error(file, "filename must be lowercase")
+    if "_" in file.stem:
+        error(file, "use hyphens, not underscores in filename")
+
+
+def check_title(file: Path, lines: list[str]) -> None:
+    if not lines or not lines[0].startswith("# "):
+        error(file, "must start with a top-level '# Title' heading")
+
+
+def check_sections(file: Path, content: str) -> None:
+    if not re.search(r"^## ", content, re.MULTILINE):
+        error(file, "must have at least one '## Section' heading")
+
+
+def check_code_blocks(file: Path, content: str) -> None:
+    fences = re.findall(r"^```(\w*)", content, re.MULTILINE)
+    for i, lang in enumerate(fences):
+        # opening fences (even index) must have a language tag
+        if i % 2 == 0 and not lang:
+            error(file, "code block without language tag (use ```python, ```bash, etc.)")
+            break
+
+
+def check_internal_links(file: Path, content: str) -> None:
+    links = re.findall(r"\[.*?\]\(([^)]+)\)", content)
+    for link in links:
+        if link.startswith("http") or link.startswith("#"):
+            continue
+        target = (file.parent / link.split("#")[0]).resolve()
+        if not target.exists():
+            error(file, f"broken internal link: {link}")
+
+
+def validate_docs() -> None:
+    md_files = list(DOCS_DIR.rglob("*.md"))
+    if not md_files:
+        print("No docs found.")
+        return
+
+    for file in md_files:
+        content = file.read_text(encoding="utf-8")
+        lines = content.strip().splitlines()
+
+        check_filename(file)
+        check_title(file, lines)
+        check_sections(file, content)
+        check_code_blocks(file, content)
+        check_internal_links(file, content)
+
+
+if __name__ == "__main__":
+    validate_docs()
+
+    if ERRORS:
+        print(f"Found {len(ERRORS)} error(s):\n")
+        for e in ERRORS:
+            print(f"  FAIL: {e}")
+        sys.exit(1)
+    else:
+        print("All docs passed validation.")

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,138 @@
+"""Validate skills/ files against docs/contrib/skills-rules.md."""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = ROOT / "skills"
+ERRORS: list[str] = []
+
+
+def error(skill: str, msg: str) -> None:
+    ERRORS.append(f"skills/{skill}: {msg}")
+
+
+def parse_frontmatter(content: str) -> dict[str, str]:
+    """Extract YAML frontmatter as a simple key-value dict."""
+    match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return {}
+    fm: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip()
+            # handle multi-line description with '>'
+            if value == ">":
+                continue
+            if key and value:
+                fm[key] = value
+            elif key and not value:
+                # might be a continuation line from '>' — check next
+                fm.setdefault(key, "")
+    return fm
+
+
+def check_skill_md_exists(skill_dir: Path) -> bool:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        error(skill_dir.name, "missing SKILL.md")
+        return False
+    return True
+
+
+def check_frontmatter(skill_dir: Path, content: str) -> None:
+    name = skill_dir.name
+    fm = parse_frontmatter(content)
+
+    if "name" not in fm:
+        error(name, "frontmatter missing 'name' field")
+    elif fm["name"] != name:
+        error(name, f"frontmatter name '{fm['name']}' does not match directory '{name}'")
+
+    if "description" not in fm:
+        # check for multi-line description with '>'
+        if "description:" not in content.split("---")[1] if "---" in content else "":
+            error(name, "frontmatter missing 'description' field")
+
+
+def check_title(skill_dir: Path, content: str) -> None:
+    # strip frontmatter
+    body = re.sub(r"^---.*?---\s*", "", content, flags=re.DOTALL)
+    lines = body.strip().splitlines()
+    if not lines or not lines[0].startswith("# "):
+        error(skill_dir.name, "missing top-level '# Title' heading")
+
+
+def check_required_sections(skill_dir: Path, content: str) -> None:
+    body = re.sub(r"^---.*?---\s*", "", content, flags=re.DOTALL)
+    headings = re.findall(r"^## (.+)", body, re.MULTILINE)
+
+    has_input = any(
+        h.lower().startswith(("input", "before you start"))
+        for h in headings
+    )
+    if not has_input:
+        error(skill_dir.name, "missing '## Input' or '## Before You Start' section")
+
+    # must have at least one other section beyond input
+    if len(headings) < 2:
+        error(skill_dir.name, "must have at least one workflow section beyond input/prerequisites")
+
+
+def check_empty_sections(skill_dir: Path, content: str) -> None:
+    body = re.sub(r"^---.*?---\s*", "", content, flags=re.DOTALL)
+    sections = re.split(r"^(## .+)", body, flags=re.MULTILINE)
+
+    i = 1
+    while i < len(sections) - 1:
+        heading = sections[i].strip()
+        body_text = sections[i + 1].strip()
+        if not body_text:
+            error(skill_dir.name, f"empty section: '{heading}'")
+        i += 2
+
+
+def check_dirname(skill_dir: Path) -> None:
+    name = skill_dir.name
+    if name != name.lower():
+        error(name, "directory name must be lowercase")
+    if "_" in name:
+        error(name, "use hyphens, not underscores in directory name")
+
+
+def validate_skills() -> None:
+    if not SKILLS_DIR.exists():
+        print("No skills/ directory found.")
+        return
+
+    skill_dirs = [d for d in SKILLS_DIR.iterdir() if d.is_dir()]
+    if not skill_dirs:
+        print("No skills found.")
+        return
+
+    for skill_dir in skill_dirs:
+        check_dirname(skill_dir)
+
+        if not check_skill_md_exists(skill_dir):
+            continue
+
+        content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        check_frontmatter(skill_dir, content)
+        check_title(skill_dir, content)
+        check_required_sections(skill_dir, content)
+        check_empty_sections(skill_dir, content)
+
+
+if __name__ == "__main__":
+    validate_skills()
+
+    if ERRORS:
+        print(f"Found {len(ERRORS)} error(s):\n")
+        for e in ERRORS:
+            print(f"  FAIL: {e}")
+        sys.exit(1)
+    else:
+        print("All skills passed validation.")


### PR DESCRIPTION
## Summary
- Add validation scripts (`scripts/validate_docs.py`, `scripts/validate_skills.py`) that enforce rules defined in `docs/contrib/`
- Add GitHub Actions workflow that runs on PRs touching `docs/` or `skills/`
- Auto-merge enabled on approve (squash)
- Fix code block language tags across existing docs

## Validation Checks

**docs/**
- Filename: lowercase, hyphen-separated
- Top-level `# Title` heading exists
- At least one `## Section`
- Code blocks have language tags
- Internal links point to existing files

**skills/**
- `SKILL.md` exists in each skill directory
- Frontmatter has `name` and `description`
- `name` matches directory name
- Required sections present (input/prerequisites + workflow)
- No empty sections

## Test plan
- [x] `python scripts/validate_docs.py` passes locally
- [x] `python scripts/validate_skills.py` passes locally