### PR TITLE
ci: wake openclaw via tailscale tailnet

### DIFF
--- a/.github/workflows/notify-qracer-bot.yml
+++ b/.github/workflows/notify-qracer-bot.yml
@@ -21,3 +21,10 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.OPENCLAW_HOOK_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d "{\"text\": \"PR #${{ github.event.pull_request.number }} ${{ github.event.action }}: ${{ github.event.pull_request.title }} — ${{ github.event.pull_request.html_url }}\", \"mode\": \"now\"}"
+
+      - name: Notify Telegram
+        run: |
+          TEXT="PR #${{ github.event.pull_request.number }} ${{ github.event.action }}%0A${{ github.event.pull_request.title }}%0ABy: ${{ github.event.pull_request.user.login }}%0A${{ github.event.pull_request.html_url }}"
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d "text=${TEXT}"


### PR DESCRIPTION
Funnel 대신 Tailscale GitHub Action으로 Runner를 Tailnet에 연결, 내부 IP로 직접 wake 호출.