### PR TITLE
fix: resolve CI lint and validate-docs failures

### DIFF
--- a/docs/user-experience.md
+++ b/docs/user-experience.md
@@ -22,28 +22,28 @@ Users speak naturally, Agent understands and acts.
 ### Input Patterns
 
 **Ticker Mention**
-```
+```text
 "How's AAPL?"
 "Show me Apple stock"
 "Compare TSLA and NVDA"
 ```
 
 **Sector/Theme Mention**
-```
+```text
 "Analyze semiconductor sector"
 "What AI stocks are there?"
 "Tell me about EV battery theme"
 ```
 
 **Portfolio Related**
-```
+```text
 "Check my portfolio risk"
 "How's my portfolio doing?"
 "Risk check my new position"
 ```
 
 **Complex Questions**
-```
+```text
 "Any semiconductor stocks with PE under 20 worth buying?"
 "What correlates highly with my portfolio?"
 "Which stocks report earnings next week?"
@@ -52,19 +52,19 @@ Users speak naturally, Agent understands and acts.
 ### Agent Response Patterns
 
 **When Clarification Needed**
-```
+```text
 User: "Recommend stocks to buy"
 Agent: "Which sector or theme? Or search the whole market?"
 ```
 
 **When Additional Info Needed**
-```
+```text
 User: "How's this stock?"
 Agent: "Which stock? Recently mentioned: AAPL, TSLA, NVDA?"
 ```
 
 **When Ambiguous**
-```
+```text
 User: "Looks good"
 Agent: "AAPL, right? Analysis from buy perspective?"
 ```
@@ -76,7 +76,7 @@ Agent: "AAPL, right? Analysis from buy perspective?"
 ### 3.1 Technical Implementation
 
 **Memory Structure**
-```
+```text
 Session Memory (Redis/SQLite)
 ├── session_id: uuid
 ├── user_id: telegram_id
@@ -120,7 +120,7 @@ Session Memory (Redis/SQLite)
 ### 3.2 User Experience Flow
 
 **Normal Flow Example**
-```
+```text
 User:  "Analyze AAPL"
 Agent: [Provides AAPL deep analysis]
        Current: AAPL | Depth: deep
@@ -139,7 +139,7 @@ Agent: [Provides TSLA deep analysis]
 ```
 
 **Context Switch Example**
-```
+```text
 User:  "Analyze AAPL"
 Agent: [Analysis] Current: AAPL
 
@@ -153,7 +153,7 @@ Agent: [AAPL real-time summary] Depth: quick
 ### 3.3 Complex Scenario Handling
 
 **Multiple Topics Mixed**
-```
+```text
 User: "Which is better, AAPL or TSLA?"
 → Stack: [AAPL, TSLA] (equal priority)
 → Comparison mode activated
@@ -164,7 +164,7 @@ User: "But NVDA also looks good"
 ```
 
 **Ambiguous Pronouns**
-```
+```text
 User: "Analyze AAPL"
 Agent: [Provides analysis]
 
@@ -180,7 +180,7 @@ User: "This looks risky"
 ```
 
 **Conflict Resolution**
-```
+```text
 User: "Any good semiconductor stocks?"
 Agent: [Semiconductor sector analysis] Current: semiconductors
 
@@ -192,7 +192,7 @@ User: "What about AAPL?"  # sector → ticker switch
 ### 3.4 Agent Decision Logic
 
 **Context Retention Decision Tree**
-```
+```text
 New message arrives
 ├── Ticker/sector mentioned?
 │   ├── Yes → Switch to that topic
@@ -226,7 +226,7 @@ New message arrives
 ### 3.5 Unknown Topic Handling
 
 **Search Priority**
-```
+```text
 Unknown topic "XYZ" appears
   ↓
 1. Local Context (instant, <100ms)
@@ -246,7 +246,7 @@ Unknown topic "XYZ" appears
 ```
 
 **Handling Example**
-```
+```text
 User: "What's QuantumScape?"
   ↓
 [Local/embedding search] None
@@ -283,7 +283,7 @@ qracer main interface. Left sidebar menu + right info panel structure.
 
 ### Layout
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │  qracer                                                 │
 ├──────────┬──────────────────────────────────────────────┤
@@ -333,7 +333,7 @@ qracer main interface. Left sidebar menu + right info panel structure.
 ### Main Panel Components
 
 **Overview Example**
-```
+```text
 ┌────────────────────────────────────────┐
 │  Portfolio Summary                     │
 │  AAPL  $175.20  +1.2%   $12,450        │
@@ -354,7 +354,7 @@ qracer main interface. Left sidebar menu + right info panel structure.
 ### Interaction Patterns
 
 **Dashboard → Chat Transition**
-```
+```text
 1. Click AAPL in Overview
 2. Auto opens New Chat
 3. Agent: "Tell you about AAPL?"
@@ -362,7 +362,7 @@ qracer main interface. Left sidebar menu + right info panel structure.
 ```
 
 **Chat Referencing Dashboard**
-```
+```text
 User: "Check my portfolio risk"
 Agent: [Provides portfolio risk analysis]
       "You can also check real-time risk gauge in Overview tab."
@@ -411,7 +411,7 @@ uv add qracer
 
 After install, run `qracer install` for initial setup:
 
-```
+```text
 $ qracer install
 
 🎯 Starting qracer installation.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -4,7 +4,7 @@ The tracer workspace is a single directory containing all project files.
 
 ## Structure
 
-```
+```text
 tracer/
 ├── src/tracer/       # Source code
 ├── tests/            # Test suite

--- a/src/tracer/agents/analyst.py
+++ b/src/tracer/agents/analyst.py
@@ -139,8 +139,7 @@ class Analyst(BaseAgent):
                             data={
                                 "ticker": ticker,
                                 "articles": [
-                                    {"title": a.title, "sentiment": a.sentiment}
-                                    for a in articles
+                                    {"title": a.title, "sentiment": a.sentiment} for a in articles
                                 ],
                             },
                             source="NewsProvider",

--- a/src/tracer/agents/reporter.py
+++ b/src/tracer/agents/reporter.py
@@ -100,9 +100,7 @@ class Reporter(BaseAgent):
             conviction=primary.conviction,
             what_happened=report_data.get("what_happened", primary.thesis),
             evidence_chain=report_data.get("evidence_chain", primary.evidence),
-            adversarial_check=report_data.get(
-                "adversarial_check", primary.risk_factors
-            ),
+            adversarial_check=report_data.get("adversarial_check", primary.risk_factors),
             verdict=report_data.get("verdict", primary.thesis),
             signals=signals,
         )

--- a/src/tracer/agents/researcher.py
+++ b/src/tracer/agents/researcher.py
@@ -9,7 +9,6 @@ from tracer.agents.base import BaseAgent
 from tracer.data.providers import (
     FundamentalProvider,
     NewsProvider,
-    PriceProvider,
 )
 from tracer.llm.providers import Role
 from tracer.models import Stock, ToolResult
@@ -79,11 +78,7 @@ class Researcher(BaseAgent):
         # Apply hard market-cap filter before LLM call
         filtered = successful
         if min_market_cap is not None:
-            filtered = [
-                r
-                for r in successful
-                if (r.data.get("market_cap") or 0) >= min_market_cap
-            ]
+            filtered = [r for r in successful if (r.data.get("market_cap") or 0) >= min_market_cap]
 
         if not filtered:
             return []
@@ -110,9 +105,7 @@ class Researcher(BaseAgent):
         except (json.JSONDecodeError, ValueError):
             selected = [r.data["ticker"] for r in filtered if "ticker" in r.data]
 
-        return [
-            Stock(ticker=t, name=t) for t in selected if isinstance(t, str)
-        ]
+        return [Stock(ticker=t, name=t) for t in selected if isinstance(t, str)]
 
     async def map_consensus(self, ticker: str) -> dict:
         """Build a consensus view for a ticker using news and alternative data.

--- a/src/tracer/agents/strategist.py
+++ b/src/tracer/agents/strategist.py
@@ -121,9 +121,7 @@ class Strategist(BaseAgent):
         signals.sort(key=lambda sig: sig.conviction, reverse=True)
         return signals
 
-    async def run(
-        self, cross_market: dict, consensus: dict, **kwargs
-    ) -> list[Signal]:
+    async def run(self, cross_market: dict, consensus: dict, **kwargs) -> list[Signal]:
         """Default entry point — detect contrarian signals and score them."""
         contrarian = await self.detect_contrarian(cross_market, consensus)
         return await self.score_signals(contrarian)

--- a/src/tracer/conversation/engine.py
+++ b/src/tracer/conversation/engine.py
@@ -57,9 +57,7 @@ class EngineResponse:
     generated_at: datetime = field(default_factory=datetime.now)
 
 
-async def _invoke_tool(
-    tool_name: str, intent: Intent, registry: DataRegistry
-) -> ToolResult:
+async def _invoke_tool(tool_name: str, intent: Intent, registry: DataRegistry) -> ToolResult:
     """Invoke a single pipeline tool based on the intent context."""
     tickers = intent.tickers
 
@@ -171,9 +169,7 @@ class AnalysisLoop:
             iterations=iterations,
         )
 
-    async def _evaluate(
-        self, intent: Intent, results: list[ToolResult]
-    ) -> tuple[float, list[str]]:
+    async def _evaluate(self, intent: Intent, results: list[ToolResult]) -> tuple[float, list[str]]:
         """Ask the analyst LLM to evaluate confidence and suggest missing tools.
 
         Returns (confidence, list_of_missing_tool_names).
@@ -184,7 +180,7 @@ class AnalysisLoop:
             "answer a financial query.\n"
             "Available tools: price_event, news, insider, macro, fundamentals, "
             "cross_market, memory_search.\n"
-            "Return JSON: {\"confidence\": 0.0-1.0, \"missing_tools\": [...]}\n"
+            'Return JSON: {"confidence": 0.0-1.0, "missing_tools": [...]}\n'
             "confidence = how confident you are the data answers the query.\n"
             "missing_tools = tools not yet called that would improve the answer "
             "(empty list if sufficient).\n"
@@ -206,9 +202,7 @@ class AnalysisLoop:
             )
             parsed = json.loads(response.content)
             confidence = float(parsed.get("confidence", 0.0))
-            missing = [
-                t for t in parsed.get("missing_tools", []) if t in _TOOL_DISPATCH
-            ]
+            missing = [t for t in parsed.get("missing_tools", []) if t in _TOOL_DISPATCH]
             # Don't re-call tools we already have results for.
             already_called = {r.tool for r in results}
             missing = [t for t in missing if t not in already_called]
@@ -230,9 +224,7 @@ class ResponseSynthesizer:
 
     async def synthesize(self, intent: Intent, analysis: AnalysisResult) -> str:
         """Generate the final user-facing response."""
-        evidence = _format_evidence(
-            [r for r in analysis.results if r.success]
-        )
+        evidence = _format_evidence([r for r in analysis.results if r.success])
         failed_tools = [r.tool for r in analysis.results if not r.success]
 
         ticker_str = ", ".join(intent.tickers) if intent.tickers else "general market"
@@ -377,7 +369,6 @@ def _format_evidence(results: list[ToolResult]) -> str:
     sections: list[str] = []
     for r in results:
         sections.append(
-            f"[{r.tool}] source={r.source} stale={r.is_stale}\n"
-            f"{json.dumps(r.data, indent=2)}"
+            f"[{r.tool}] source={r.source} stale={r.is_stale}\n{json.dumps(r.data, indent=2)}"
         )
     return "\n\n".join(sections)

--- a/src/tracer/conversation/intent.py
+++ b/src/tracer/conversation/intent.py
@@ -57,9 +57,7 @@ class Intent:
     def __post_init__(self) -> None:
         # If no explicit tools, fill from the default map.
         if not self.tools:
-            object.__setattr__(
-                self, "tools", list(INTENT_TOOL_MAP.get(self.intent_type, []))
-            )
+            object.__setattr__(self, "tools", list(INTENT_TOOL_MAP.get(self.intent_type, [])))
 
 
 _SYSTEM_PROMPT = """\

--- a/src/tracer/data/providers.py
+++ b/src/tracer/data/providers.py
@@ -76,9 +76,7 @@ class PriceProvider(Protocol):
 
     async def get_price(self, ticker: str) -> float: ...
 
-    async def get_ohlcv(
-        self, ticker: str, start: date, end: date
-    ) -> list[OHLCV]: ...
+    async def get_ohlcv(self, ticker: str, start: date, end: date) -> list[OHLCV]: ...
 
 
 @runtime_checkable
@@ -106,6 +104,4 @@ class NewsProvider(Protocol):
 class AlternativeProvider(Protocol):
     """Capability: Alternative data retrieval (insider trades, etc.)."""
 
-    async def get_alternative(
-        self, ticker: str, record_type: str
-    ) -> list[AlternativeRecord]: ...
+    async def get_alternative(self, ticker: str, record_type: str) -> list[AlternativeRecord]: ...

--- a/src/tracer/data/registry.py
+++ b/src/tracer/data/registry.py
@@ -60,9 +60,7 @@ class DataRegistry:
             for adapter_name, adapter in adapters:
                 if adapter_name == name:
                     return adapter
-            raise KeyError(
-                f"No adapter named '{name}' for capability {capability.__name__}"
-            )
+            raise KeyError(f"No adapter named '{name}' for capability {capability.__name__}")
 
         # Return the first (highest priority) adapter
         return adapters[0][1]

--- a/src/tracer/data/yfinance_adapter.py
+++ b/src/tracer/data/yfinance_adapter.py
@@ -56,9 +56,7 @@ class YfinanceAdapter:
 
     def __init__(self) -> None:
         if not _HAS_YFINANCE:
-            raise ImportError(
-                "yfinance is not installed. Install it with: uv add yfinance"
-            )
+            raise ImportError("yfinance is not installed. Install it with: uv add yfinance")
 
     async def get_price(self, ticker: str) -> float:
         """Get the latest closing price for a ticker."""

--- a/src/tracer/llm/claude_adapter.py
+++ b/src/tracer/llm/claude_adapter.py
@@ -55,9 +55,7 @@ class ClaudeAdapter:
         model_map: dict[Role, str] | None = None,
     ) -> None:
         if not _HAS_ANTHROPIC:
-            raise ImportError(
-                "anthropic is not installed. Install it with: uv add anthropic"
-            )
+            raise ImportError("anthropic is not installed. Install it with: uv add anthropic")
         self._client = anthropic.AsyncAnthropic(api_key=api_key)
         self._model_map = model_map or dict(DEFAULT_MODEL_MAP)
 

--- a/src/tracer/memory/memory_searcher.py
+++ b/src/tracer/memory/memory_searcher.py
@@ -135,9 +135,7 @@ class MemorySearcher:
 
     def remove(self, session_id: str) -> None:
         """Remove a session from the index."""
-        self._conn.execute(
-            "DELETE FROM session_index WHERE session_id = ?", [session_id]
-        )
+        self._conn.execute("DELETE FROM session_index WHERE session_id = ?", [session_id])
         self._fts_dirty = True
 
     def close(self) -> None:

--- a/src/tracer/storage/repositories.py
+++ b/src/tracer/storage/repositories.py
@@ -20,9 +20,7 @@ class PriceRepository:
         """Insert or replace OHLCV bars. Returns number of rows affected."""
         if not bars:
             return 0
-        data = [
-            (ticker, b.date, b.open, b.high, b.low, b.close, b.volume) for b in bars
-        ]
+        data = [(ticker, b.date, b.open, b.high, b.low, b.close, b.volume) for b in bars]
         self._conn.executemany(
             """
             INSERT OR REPLACE INTO prices (ticker, date, open, high, low, close, volume)
@@ -44,8 +42,7 @@ class PriceRepository:
             [ticker, start, end],
         ).fetchall()
         return [
-            OHLCV(date=r[0], open=r[1], high=r[2], low=r[3], close=r[4], volume=r[5])
-            for r in rows
+            OHLCV(date=r[0], open=r[1], high=r[2], low=r[3], close=r[4], volume=r[5]) for r in rows
         ]
 
     def latest_date(self, ticker: str) -> date | None:

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -9,17 +9,15 @@ import pytest
 
 from tracer.agents import Analyst, BaseAgent, Reporter, Researcher, Strategist
 from tracer.data.providers import (
-    AlternativeRecord,
+    OHLCV,
     FundamentalData,
     MacroIndicator,
     NewsArticle,
-    OHLCV,
 )
 from tracer.data.registry import DataRegistry
 from tracer.llm.providers import CompletionRequest, CompletionResponse, Role
 from tracer.llm.registry import LLMRegistry
 from tracer.models import Signal, SignalDirection
-
 
 # ---------------------------------------------------------------------------
 # Fakes
@@ -49,9 +47,7 @@ class FakePriceProvider:
         return 150.0
 
     async def get_ohlcv(self, ticker: str, start: date, end: date) -> list[OHLCV]:
-        return [
-            OHLCV(date=date(2024, 1, 1), open=100, high=105, low=99, close=102, volume=1000)
-        ]
+        return [OHLCV(date=date(2024, 1, 1), open=100, high=105, low=99, close=102, volume=1000)]
 
 
 class FakeFundamentalProvider:
@@ -63,9 +59,7 @@ class FakeFundamentalProvider:
 
 class FakeMacroProvider:
     async def get_indicator(self, name: str) -> MacroIndicator:
-        return MacroIndicator(
-            name=name, value=3.5, date=date(2024, 1, 1), source="test", unit="%"
-        )
+        return MacroIndicator(name=name, value=3.5, date=date(2024, 1, 1), source="test", unit="%")
 
 
 class FakeNewsProvider:
@@ -336,7 +330,13 @@ class TestStrategist:
 
     async def test_run_full_pipeline(self) -> None:
         contrarian = [
-            {"ticker": "TSLA", "thesis": "t", "contrarian_angle": "c", "direction": "long", "evidence": []}
+            {
+                "ticker": "TSLA",
+                "thesis": "t",
+                "contrarian_angle": "c",
+                "direction": "long",
+                "evidence": [],
+            }
         ]
         scored = [
             {
@@ -351,7 +351,6 @@ class TestStrategist:
             }
         ]
         # First call returns contrarian, second call returns scored
-        call_count = 0
         responses = [json.dumps(contrarian), json.dumps(scored)]
 
         class MultiResponseLLM:
@@ -361,7 +360,13 @@ class TestStrategist:
             async def complete(self, request: CompletionRequest) -> CompletionResponse:
                 content = responses[self.idx]
                 self.idx += 1
-                return CompletionResponse(content=content, model="fake", input_tokens=0, output_tokens=0, cost=0.0)
+                return CompletionResponse(
+                    content=content,
+                    model="fake",
+                    input_tokens=0,
+                    output_tokens=0,
+                    cost=0.0,
+                )
 
         llm = LLMRegistry()
         llm.register("fake", MultiResponseLLM(), [Role.STRATEGIST])

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -36,11 +36,13 @@ def _mock_llm_registry(responses: dict[Role, str | list[str]]) -> LLMRegistry:
         provider = AsyncMock()
         if isinstance(content, list):
             contents = list(content)
+
             async def _complete(req, _contents=contents):
                 c = _contents.pop(0) if _contents else "{}"
                 return CompletionResponse(
                     content=c, model="mock", input_tokens=10, output_tokens=5, cost=0.0
                 )
+
             provider.complete = _complete
         else:
             provider.complete.return_value = CompletionResponse(
@@ -149,9 +151,11 @@ class TestInvokeTool:
 class TestAnalysisLoop:
     async def test_exits_on_high_confidence(self) -> None:
         """Loop should exit after first evaluation if confidence is high."""
-        llm = _mock_llm_registry({
-            Role.ANALYST: json.dumps({"confidence": 0.9, "missing_tools": []}),
-        })
+        llm = _mock_llm_registry(
+            {
+                Role.ANALYST: json.dumps({"confidence": 0.9, "missing_tools": []}),
+            }
+        )
         loop = AnalysisLoop(llm, DataRegistry())
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
 
@@ -196,15 +200,15 @@ class TestAnalysisLoop:
 
     async def test_early_exit_on_multiple_failures(self) -> None:
         """Loop should exit early if >=2 tools fail in first iteration."""
-        llm = _mock_llm_registry({
-            Role.ANALYST: json.dumps({"confidence": 0.5, "missing_tools": []}),
-        })
+        llm = _mock_llm_registry(
+            {
+                Role.ANALYST: json.dumps({"confidence": 0.5, "missing_tools": []}),
+            }
+        )
         loop = AnalysisLoop(llm, DataRegistry())
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
 
-        result = await loop.run(
-            intent, [_failed_result("price_event"), _failed_result("news")]
-        )
+        result = await loop.run(intent, [_failed_result("price_event"), _failed_result("news")])
         assert result.early_exit_reason is not None
         assert "2 tools failed" in result.early_exit_reason
 
@@ -223,9 +227,11 @@ class TestAnalysisLoop:
 
     async def test_no_missing_tools_exits(self) -> None:
         """If analyst says no missing tools but confidence is low, exit."""
-        llm = _mock_llm_registry({
-            Role.ANALYST: json.dumps({"confidence": 0.5, "missing_tools": []}),
-        })
+        llm = _mock_llm_registry(
+            {
+                Role.ANALYST: json.dumps({"confidence": 0.5, "missing_tools": []}),
+            }
+        )
         loop = AnalysisLoop(llm, DataRegistry())
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
 
@@ -240,14 +246,14 @@ class TestAnalysisLoop:
 
 class TestResponseSynthesizer:
     async def test_synthesize_calls_strategist(self) -> None:
-        llm = _mock_llm_registry({
-            Role.STRATEGIST: "[ANALYSIS: AAPL]\nConviction: 8/10\n...",
-        })
+        llm = _mock_llm_registry(
+            {
+                Role.STRATEGIST: "[ANALYSIS: AAPL]\nConviction: 8/10\n...",
+            }
+        )
         synth = ResponseSynthesizer(llm)
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
-        analysis = AnalysisResult(
-            results=[_ok_result("price_event")], confidence=0.8, iterations=1
-        )
+        analysis = AnalysisResult(results=[_ok_result("price_event")], confidence=0.8, iterations=1)
 
         text = await synth.synthesize(intent, analysis)
         assert "ANALYSIS" in text
@@ -272,9 +278,11 @@ class TestResponseSynthesizer:
         assert "LLM error" in text
 
     async def test_includes_failed_tools_in_caveats(self) -> None:
-        llm = _mock_llm_registry({
-            Role.STRATEGIST: "[ANALYSIS] with insider caveat",
-        })
+        llm = _mock_llm_registry(
+            {
+                Role.STRATEGIST: "[ANALYSIS] with insider caveat",
+            }
+        )
         synth = ResponseSynthesizer(llm)
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
         analysis = AnalysisResult(
@@ -300,11 +308,13 @@ class TestConversationEngine:
         analysis_resp = json.dumps({"confidence": 0.85, "missing_tools": []})
         synth_resp = "[ANALYSIS: AAPL — 2025-01-01]\nConviction: 8/10\nTest response"
 
-        llm = _mock_llm_registry({
-            Role.RESEARCHER: intent_resp,
-            Role.ANALYST: analysis_resp,
-            Role.STRATEGIST: synth_resp,
-        })
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: intent_resp,
+                Role.ANALYST: analysis_resp,
+                Role.STRATEGIST: synth_resp,
+            }
+        )
         data = DataRegistry()
 
         engine = ConversationEngine(llm, data)
@@ -324,11 +334,13 @@ class TestConversationEngine:
         intent_resp = json.dumps({"intent": "macro_query", "tickers": []})
         analysis_resp = json.dumps({"confidence": 0.9, "missing_tools": []})
 
-        llm = _mock_llm_registry({
-            Role.RESEARCHER: intent_resp,
-            Role.ANALYST: analysis_resp,
-            Role.STRATEGIST: "Macro analysis response",
-        })
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: intent_resp,
+                Role.ANALYST: analysis_resp,
+                Role.STRATEGIST: "Macro analysis response",
+            }
+        )
 
         engine = ConversationEngine(llm, DataRegistry())
 
@@ -343,11 +355,13 @@ class TestConversationEngine:
     async def test_custom_thresholds(self) -> None:
         """Engine should accept custom max_iterations and confidence_threshold."""
         engine = ConversationEngine(
-            _mock_llm_registry({
-                Role.RESEARCHER: json.dumps({"intent": "macro_query", "tickers": []}),
-                Role.ANALYST: json.dumps({"confidence": 0.5, "missing_tools": []}),
-                Role.STRATEGIST: "response",
-            }),
+            _mock_llm_registry(
+                {
+                    Role.RESEARCHER: json.dumps({"intent": "macro_query", "tickers": []}),
+                    Role.ANALYST: json.dumps({"confidence": 0.5, "missing_tools": []}),
+                    Role.STRATEGIST: "response",
+                }
+            ),
             DataRegistry(),
             max_iterations=1,
             confidence_threshold=0.9,

--- a/tests/memory/test_session_compactor.py
+++ b/tests/memory/test_session_compactor.py
@@ -32,12 +32,8 @@ def mock_registry() -> LLMRegistry:
 def session_logger(tmp_path: Path) -> SessionLogger:
     logger = SessionLogger(tmp_path / "test.jsonl")
     logger.append(TurnRecord(turn=1, role="user", content="Why did AAPL spike?"))
-    logger.append(
-        TurnRecord(turn=1, role="tool_call", content="Fetching news", tool="fetch_news")
-    )
-    logger.append(
-        TurnRecord(turn=1, role="tool_result", content="Earnings beat", success=True)
-    )
+    logger.append(TurnRecord(turn=1, role="tool_call", content="Fetching news", tool="fetch_news"))
+    logger.append(TurnRecord(turn=1, role="tool_result", content="Earnings beat", success=True))
     logger.append(
         TurnRecord(turn=1, role="assistant", content="AAPL spiked due to earnings.", conviction=8)
     )
@@ -78,9 +74,7 @@ class TestSessionCompactor:
         assert md_path.exists()
         assert md_path.read_text(encoding="utf-8") == result.summary
 
-    async def test_needs_compaction(
-        self, mock_registry: LLMRegistry, tmp_path: Path
-    ) -> None:
+    async def test_needs_compaction(self, mock_registry: LLMRegistry, tmp_path: Path) -> None:
         compactor = SessionCompactor(mock_registry, token_threshold=10)
         logger = SessionLogger(tmp_path / "small.jsonl")
         assert not compactor.needs_compaction(logger)

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -23,8 +23,7 @@ class TestTracerDB:
         with TracerDB() as db:
             db._init_schema()  # noqa: SLF001
             tables = db.connection.execute(
-                "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = 'main'"
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
             ).fetchall()
             assert len([t for t in tables if t[0] == "prices"]) == 1
 

--- a/tests/tools/test_pipeline.py
+++ b/tests/tools/test_pipeline.py
@@ -46,8 +46,12 @@ class TestPriceEvent:
         mock.get_price.return_value = 185.0
         mock.get_ohlcv.return_value = [
             OHLCV(
-                date=date(2024, 1, 1), open=180.0, high=186.0,
-                low=179.0, close=185.0, volume=1000,
+                date=date(2024, 1, 1),
+                open=180.0,
+                high=186.0,
+                low=179.0,
+                close=185.0,
+                volume=1000,
             ),
         ]
         result = await price_event("AAPL", _registry_with(PriceProvider, mock))


### PR DESCRIPTION
## Summary
- **ruff check**: fix 6 errors — unused imports (F401), unsorted imports (I001), unused variable (F841), line too long (E501)
- **ruff format**: reformat 17 files to match project style
- **validate-docs**: add `text` language tags to bare code fences in `workspace.md` and `user-experience.md`

Note: pyright type errors (53) are pre-existing and deferred to a separate PR.

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `python scripts/validate_docs.py` passes