### PR TITLE
fix: resolve all 53 pyright type errors

### DIFF
--- a/src/tracer/data/registry.py
+++ b/src/tracer/data/registry.py
@@ -8,18 +8,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from tracer.data.providers import (
-    AlternativeProvider,
-    FundamentalProvider,
-    MacroProvider,
-    NewsProvider,
-    PriceProvider,
-)
-
-# Union of all provider protocols
-ProviderType = type[
-    PriceProvider | FundamentalProvider | MacroProvider | NewsProvider | AlternativeProvider
-]
+# Provider protocol classes are used as capability keys (e.g. PriceProvider, NewsProvider).
+# pyright doesn't support type[Protocol], so we use type[Any] as the capability type.
+ProviderType = type[Any]
 
 
 class DataRegistry:

--- a/src/tracer/data/yfinance_adapter.py
+++ b/src/tracer/data/yfinance_adapter.py
@@ -35,15 +35,25 @@ def _fetch_ohlcv(ticker: str, start: date, end: date) -> list[OHLCV]:
     if hist.empty:
         return []
     bars: list[OHLCV] = []
+    from typing import cast
+
+    import pandas as pd
+
     for idx, row in hist.iterrows():
+        ts = cast(pd.Timestamp, idx)
+        o = cast(float, row["Open"])
+        h = cast(float, row["High"])
+        lo = cast(float, row["Low"])
+        c = cast(float, row["Close"])
+        v = cast(int, row["Volume"])
         bars.append(
             OHLCV(
-                date=idx.date(),
-                open=float(row["Open"]),
-                high=float(row["High"]),
-                low=float(row["Low"]),
-                close=float(row["Close"]),
-                volume=int(row["Volume"]),
+                date=ts.date(),
+                open=float(o),
+                high=float(h),
+                low=float(lo),
+                close=float(c),
+                volume=int(v),
             )
         )
     return bars

--- a/src/tracer/llm/claude_adapter.py
+++ b/src/tracer/llm/claude_adapter.py
@@ -16,7 +16,7 @@ from tracer.llm.providers import (
 )
 
 try:
-    import anthropic
+    import anthropic  # pyright: ignore[reportMissingImports]
 
     _HAS_ANTHROPIC = True
 except ImportError:

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -125,7 +125,7 @@ class TestInvokeTool:
         registry = DataRegistry()
         result = await _invoke_tool("price_event", intent, registry)
         assert not result.success
-        assert "no tickers" in result.error
+        assert result.error is not None and "no tickers" in result.error
 
     async def test_invoke_tools_concurrent(self) -> None:
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")

--- a/tests/memory/test_memory_searcher.py
+++ b/tests/memory/test_memory_searcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -10,9 +11,9 @@ from tracer.memory.memory_searcher import MemorySearcher
 
 
 @pytest.fixture
-def searcher() -> MemorySearcher:
+def searcher() -> Iterator[MemorySearcher]:
     s = MemorySearcher()
-    yield s  # type: ignore[misc]
+    yield s
     s.close()
 
 
@@ -50,7 +51,7 @@ class TestMemorySearcher:
 
         # After removal, the table should be empty
         row = searcher.connection.execute("SELECT count(*) FROM session_index").fetchone()
-        assert row[0] == 0
+        assert row is not None and row[0] == 0
 
     def test_index_directory(self, searcher: MemorySearcher, tmp_path: Path) -> None:
         (tmp_path / "sess_001.md").write_text("# AAPL\nEarnings beat", encoding="utf-8")

--- a/tests/storage/test_repositories.py
+++ b/tests/storage/test_repositories.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import date, datetime
 
 import pytest
@@ -13,10 +14,10 @@ from tracer.storage.repositories import PriceRepository, ReportRepository, Signa
 
 
 @pytest.fixture
-def db() -> TracerDB:
+def db() -> Iterator[TracerDB]:
     """In-memory database for each test."""
     _db = TracerDB()
-    yield _db  # type: ignore[misc]
+    yield _db
     _db.close()
 
 


### PR DESCRIPTION
## Summary
- **ProviderType** (44 errors): `type[Protocol]` unions not supported by pyright — changed to `type[Any]` with comment explaining why
- **yfinance_adapter** (16 errors): cast pandas `Hashable`/`Series` to proper types via `typing.cast`
- **claude_adapter** (1 error): suppress `reportMissingImports` for optional `anthropic` dependency
- **Test fixtures** (3 errors): use `Iterator[T]` return type for `yield` fixtures
- **test_engine** (1 error): add `None` check before `in` operator on `Optional[str]`

## Test plan
- [x] `uv run pyright` — 0 errors
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run pytest` — 171 passed