### PR TITLE
feat: implement conversation context management (closes #34)

### DIFF
--- a/src/tracer/conversation/context.py
+++ b/src/tracer/conversation/context.py
@@ -1,0 +1,341 @@
+"""ConversationContext — tracks topics, intent, and depth across turns.
+
+Extracts structured context from session turn history so the engine can
+resolve pronouns, maintain topic stacks, and detect stale sessions.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from tracer.memory.session_logger import TurnRecord
+
+# Uppercase 1-5 letter words that look like tickers.
+_TICKER_RE = re.compile(r"\b([A-Z]{1,5})\b")
+
+# Common English words that match the ticker pattern but aren't tickers.
+_TICKER_STOPWORDS = frozenset(
+    {
+        "I",
+        "A",
+        "AM",
+        "AN",
+        "AS",
+        "AT",
+        "BE",
+        "BY",
+        "DO",
+        "GO",
+        "HE",
+        "IF",
+        "IN",
+        "IS",
+        "IT",
+        "ME",
+        "MY",
+        "NO",
+        "OF",
+        "OK",
+        "ON",
+        "OR",
+        "SO",
+        "TO",
+        "UP",
+        "US",
+        "WE",
+        "AND",
+        "ARE",
+        "BUT",
+        "CAN",
+        "DID",
+        "FOR",
+        "GET",
+        "GOT",
+        "HAS",
+        "HAD",
+        "HER",
+        "HIM",
+        "HIS",
+        "HOW",
+        "ITS",
+        "LET",
+        "MAY",
+        "NOT",
+        "NOW",
+        "OLD",
+        "OUR",
+        "OWN",
+        "SAY",
+        "SHE",
+        "THE",
+        "TOO",
+        "TRY",
+        "USE",
+        "WAY",
+        "WHO",
+        "WHY",
+        "YOU",
+        "ALL",
+        "ANY",
+        "DAY",
+        "FEW",
+        "NEW",
+        "ALSO",
+        "BACK",
+        "BEEN",
+        "CALL",
+        "COME",
+        "EACH",
+        "FIND",
+        "FROM",
+        "GIVE",
+        "GOOD",
+        "HAVE",
+        "HERE",
+        "HIGH",
+        "JUST",
+        "KNOW",
+        "LAST",
+        "LIKE",
+        "LONG",
+        "LOOK",
+        "MADE",
+        "MAKE",
+        "MORE",
+        "MOST",
+        "MUCH",
+        "MUST",
+        "NAME",
+        "ONLY",
+        "OVER",
+        "PART",
+        "SAME",
+        "SHOW",
+        "SOME",
+        "SUCH",
+        "TAKE",
+        "TELL",
+        "THAN",
+        "THAT",
+        "THEM",
+        "THEN",
+        "THEY",
+        "THIS",
+        "TIME",
+        "VERY",
+        "WANT",
+        "WELL",
+        "WERE",
+        "WHAT",
+        "WHEN",
+        "WILL",
+        "WITH",
+        "WORK",
+        "YEAR",
+        "YOUR",
+        "ABOUT",
+        "AFTER",
+        "BEING",
+        "COULD",
+        "EVERY",
+        "FIRST",
+        "GREAT",
+        "NEVER",
+        "OTHER",
+        "PLACE",
+        "POINT",
+        "RIGHT",
+        "SHALL",
+        "SINCE",
+        "SMALL",
+        "STILL",
+        "THEIR",
+        "THERE",
+        "THESE",
+        "THING",
+        "THINK",
+        "THOSE",
+        "THREE",
+        "UNDER",
+        "WHERE",
+        "WHICH",
+        "WHILE",
+        "WORLD",
+        "WOULD",
+        "QUICK",
+        "BRIEF",
+        "DEEP",
+        "BUY",
+        "SELL",
+    }
+)
+
+_SECTORS = frozenset(
+    {
+        "semiconductor",
+        "tech",
+        "technology",
+        "energy",
+        "finance",
+        "financial",
+        "healthcare",
+        "biotech",
+        "retail",
+        "automotive",
+        "ev",
+        "battery",
+        "ai",
+        "cloud",
+        "crypto",
+        "real estate",
+        "defense",
+        "telecom",
+        "media",
+        "consumer",
+        "industrial",
+        "materials",
+        "utilities",
+    }
+)
+
+_INTENT_KEYWORDS: dict[str, list[str]] = {
+    "buy": ["buy", "long", "entry", "accumulate", "purchase"],
+    "sell": ["sell", "short", "exit", "dump", "liquidate"],
+    "research": ["analyze", "analysis", "research", "investigate", "look into", "tell me about"],
+    "monitor": ["monitor", "watch", "track", "alert", "notify"],
+}
+
+_DEPTH_QUICK = {"quick", "brief", "summary", "briefly", "short", "overview", "glance"}
+_DEPTH_DEEP = {"analyze", "detail", "detailed", "deep", "thorough", "comprehensive", "full"}
+
+# Pronouns that resolve to current or previous topic.
+_CURRENT_PRONOUNS = {"this", "it", "this stock", "이거", "이것"}
+_PREVIOUS_PRONOUNS = {"previous", "previous one", "전에 본 것"}
+
+_MAX_TOPIC_STACK = 5
+_DEFAULT_TURNS = 20
+
+
+@dataclass
+class ConversationContext:
+    """Structured context extracted from recent conversation turns."""
+
+    current_topic: str | None = None
+    topic_stack: list[str] = field(default_factory=list)
+    intent: str | None = None  # 'buy' | 'sell' | 'research' | 'monitor' | None
+    depth: str = "quick"
+    last_activity: datetime = field(default_factory=datetime.now)
+
+
+def extract_context(turns: list[TurnRecord]) -> ConversationContext:
+    """Parse recent user turns and build a ConversationContext.
+
+    Examines the last 20 user turns (reverse chronological) to extract
+    tickers, sectors, intent, and depth signals.
+    """
+    user_turns = [t for t in turns if t.role == "user"][-_DEFAULT_TURNS:]
+
+    if not user_turns:
+        return ConversationContext()
+
+    # Build topic stack in reverse chronological order (most recent first).
+    topic_stack: list[str] = []
+    for turn in reversed(user_turns):
+        tickers = _extract_tickers(turn.content)
+        sectors = _extract_sectors(turn.content)
+        for topic in tickers + sectors:
+            if topic not in topic_stack:
+                topic_stack.append(topic)
+            if len(topic_stack) >= _MAX_TOPIC_STACK:
+                break
+        if len(topic_stack) >= _MAX_TOPIC_STACK:
+            break
+
+    # Detect intent from most recent turns first.
+    intent: str | None = None
+    for turn in reversed(user_turns):
+        detected = _detect_intent(turn.content)
+        if detected:
+            intent = detected
+            break
+
+    # Detect depth from most recent turns first.
+    depth = "quick"
+    for turn in reversed(user_turns):
+        detected_depth = _detect_depth(turn.content)
+        if detected_depth:
+            depth = detected_depth
+            break
+
+    # Parse last_activity from the most recent turn's timestamp.
+    last_ts = user_turns[-1].ts
+    try:
+        last_activity = datetime.fromisoformat(last_ts)
+    except (ValueError, TypeError):
+        last_activity = datetime.now()
+
+    return ConversationContext(
+        current_topic=topic_stack[0] if topic_stack else None,
+        topic_stack=topic_stack,
+        intent=intent,
+        depth=depth,
+        last_activity=last_activity,
+    )
+
+
+def resolve_pronoun(pronoun: str, context: ConversationContext) -> str | None:
+    """Resolve a pronoun to a topic using the conversation context.
+
+    Returns None if the pronoun cannot be resolved.
+    """
+    p = pronoun.strip().lower()
+
+    if p in _CURRENT_PRONOUNS:
+        return context.current_topic
+
+    if p in _PREVIOUS_PRONOUNS:
+        if len(context.topic_stack) > 1:
+            return context.topic_stack[1]
+        return None
+
+    return None
+
+
+def is_stale(context: ConversationContext, ttl_minutes: int = 10) -> bool:
+    """Return True if the context's last_activity exceeds the TTL."""
+    elapsed = datetime.now() - context.last_activity
+    return elapsed.total_seconds() > ttl_minutes * 60
+
+
+def _extract_tickers(text: str) -> list[str]:
+    """Extract likely stock tickers from text."""
+    matches = _TICKER_RE.findall(text)
+    return [m for m in matches if m not in _TICKER_STOPWORDS]
+
+
+def _extract_sectors(text: str) -> list[str]:
+    """Extract sector/theme keywords from text."""
+    lower = text.lower()
+    return [s for s in _SECTORS if s in lower]
+
+
+def _detect_intent(text: str) -> str | None:
+    """Detect trading intent from text."""
+    lower = text.lower()
+    for intent, keywords in _INTENT_KEYWORDS.items():
+        if any(kw in lower for kw in keywords):
+            return intent
+    return None
+
+
+def _detect_depth(text: str) -> str | None:
+    """Detect analysis depth from text."""
+    lower = text.lower()
+    words = set(lower.split())
+    if words & _DEPTH_DEEP:
+        return "deep"
+    if words & _DEPTH_QUICK:
+        return "quick"
+    return None

--- a/src/tracer/conversation/engine.py
+++ b/src/tracer/conversation/engine.py
@@ -13,10 +13,12 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 from tracer.config.models import PortfolioConfig
+from tracer.conversation.context import ConversationContext, extract_context, resolve_pronoun
 from tracer.conversation.intent import Intent, IntentParser
 from tracer.data.registry import DataRegistry, build_registry
 from tracer.llm.providers import CompletionRequest, CompletionResponse, Message, Role
 from tracer.llm.registry import LLMRegistry
+from tracer.memory.session_logger import SessionLogger
 from tracer.models import ToolResult, TradeThesis
 from tracer.tools import pipeline
 
@@ -312,6 +314,7 @@ class ConversationEngine:
         *,
         max_iterations: int = MAX_ITERATIONS,
         confidence_threshold: float = CONFIDENCE_THRESHOLD,
+        session_logger: SessionLogger | None = None,
     ) -> None:
         if data_registry is None:
             data_registry = build_registry()
@@ -327,6 +330,8 @@ class ConversationEngine:
         self._data = data_registry
         self._portfolio_config = portfolio_config or PortfolioConfig()
         self._history: list[dict] = []
+        self._session_logger = session_logger
+        self._context: ConversationContext = ConversationContext()
 
     @property
     def history(self) -> list[dict]:
@@ -337,8 +342,25 @@ class ConversationEngine:
         """Process a user query through the full pipeline."""
         self._history.append({"role": "user", "content": user_input})
 
+        # 0. Extract conversation context from session log.
+        if self._session_logger is not None:
+            turns = self._session_logger.read_all()[-50:]
+            self._context = extract_context(turns)
+
         # 1. Parse intent.
         intent = await self._intent_parser.parse(user_input)
+
+        # 1b. If no tickers in intent, try resolving from conversation context.
+        if not intent.tickers and self._context.current_topic:
+            resolved = resolve_pronoun(user_input.strip(), self._context)
+            if resolved is None:
+                resolved = self._context.current_topic
+            intent = Intent(
+                intent_type=intent.intent_type,
+                tickers=[resolved],
+                tools=intent.tools,
+                raw_query=intent.raw_query,
+            )
         logger.info(
             "Parsed intent: %s tickers=%s tools=%s",
             intent.intent_type.value,

--- a/tests/conversation/test_context.py
+++ b/tests/conversation/test_context.py
@@ -1,0 +1,155 @@
+"""Tests for conversation context management."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from tracer.conversation.context import (
+    ConversationContext,
+    extract_context,
+    is_stale,
+    resolve_pronoun,
+)
+from tracer.memory.session_logger import TurnRecord
+
+
+def _turn(content: str, turn: int = 1, role: str = "user", ts: str | None = None) -> TurnRecord:
+    """Helper to build a TurnRecord."""
+    return TurnRecord(
+        turn=turn,
+        role=role,
+        content=content,
+        ts=ts or datetime.now().isoformat(),
+    )
+
+
+class TestExtractTickerFromTurns:
+    def test_single_ticker(self):
+        turns = [_turn("Why did AAPL spike?")]
+        ctx = extract_context(turns)
+        assert ctx.current_topic == "AAPL"
+        assert "AAPL" in ctx.topic_stack
+
+    def test_multiple_tickers(self):
+        turns = [_turn("Compare AAPL and TSLA")]
+        ctx = extract_context(turns)
+        assert ctx.current_topic in ("AAPL", "TSLA")
+        assert "AAPL" in ctx.topic_stack
+        assert "TSLA" in ctx.topic_stack
+
+    def test_no_ticker(self):
+        turns = [_turn("How is the market doing?")]
+        ctx = extract_context(turns)
+        # No ticker, but might pick up a sector or be None.
+        assert ctx.current_topic is None or isinstance(ctx.current_topic, str)
+
+
+class TestTopicStackOrder:
+    def test_most_recent_first(self):
+        turns = [
+            _turn("Analyze AAPL", turn=1),
+            _turn("Now check TSLA", turn=2),
+            _turn("What about NVDA?", turn=3),
+        ]
+        ctx = extract_context(turns)
+        assert ctx.topic_stack[0] == "NVDA"
+        assert ctx.current_topic == "NVDA"
+        # Earlier tickers should follow.
+        assert "TSLA" in ctx.topic_stack
+        assert "AAPL" in ctx.topic_stack
+        assert ctx.topic_stack.index("NVDA") < ctx.topic_stack.index("TSLA")
+        assert ctx.topic_stack.index("TSLA") < ctx.topic_stack.index("AAPL")
+
+    def test_max_five_topics(self):
+        tickers = ["AAPL", "TSLA", "NVDA", "GOOG", "MSFT", "AMZN"]
+        turns = [_turn(f"Check {t}", turn=i) for i, t in enumerate(tickers)]
+        ctx = extract_context(turns)
+        assert len(ctx.topic_stack) <= 5
+
+
+class TestResolvePronounCurrent:
+    def test_this(self):
+        ctx = ConversationContext(current_topic="AAPL", topic_stack=["AAPL"])
+        assert resolve_pronoun("this", ctx) == "AAPL"
+
+    def test_it(self):
+        ctx = ConversationContext(current_topic="TSLA", topic_stack=["TSLA"])
+        assert resolve_pronoun("it", ctx) == "TSLA"
+
+    def test_korean_pronoun(self):
+        ctx = ConversationContext(current_topic="NVDA", topic_stack=["NVDA"])
+        assert resolve_pronoun("이거", ctx) == "NVDA"
+
+    def test_no_current_topic(self):
+        ctx = ConversationContext()
+        assert resolve_pronoun("this", ctx) is None
+
+
+class TestResolvePronounPrevious:
+    def test_previous(self):
+        ctx = ConversationContext(
+            current_topic="TSLA",
+            topic_stack=["TSLA", "AAPL"],
+        )
+        assert resolve_pronoun("previous", ctx) == "AAPL"
+
+    def test_korean_previous(self):
+        ctx = ConversationContext(
+            current_topic="TSLA",
+            topic_stack=["TSLA", "AAPL"],
+        )
+        assert resolve_pronoun("전에 본 것", ctx) == "AAPL"
+
+    def test_no_previous(self):
+        ctx = ConversationContext(
+            current_topic="AAPL",
+            topic_stack=["AAPL"],
+        )
+        assert resolve_pronoun("previous", ctx) is None
+
+
+class TestIsStale:
+    def test_fresh_context(self):
+        ctx = ConversationContext(last_activity=datetime.now())
+        assert is_stale(ctx) is False
+
+    def test_stale_context(self):
+        ctx = ConversationContext(last_activity=datetime.now() - timedelta(minutes=15))
+        assert is_stale(ctx) is True
+
+    def test_custom_ttl(self):
+        ctx = ConversationContext(last_activity=datetime.now() - timedelta(minutes=5))
+        assert is_stale(ctx, ttl_minutes=3) is True
+        assert is_stale(ctx, ttl_minutes=10) is False
+
+
+class TestDepthDetection:
+    def test_quick_depth(self):
+        turns = [_turn("Give me a quick summary of AAPL")]
+        ctx = extract_context(turns)
+        assert ctx.depth == "quick"
+
+    def test_deep_depth(self):
+        turns = [_turn("Give me a detailed analysis of TSLA")]
+        ctx = extract_context(turns)
+        assert ctx.depth == "deep"
+
+    def test_default_depth(self):
+        turns = [_turn("How is AAPL?")]
+        ctx = extract_context(turns)
+        assert ctx.depth == "quick"
+
+
+class TestEmptyTurns:
+    def test_empty_turns_returns_empty_context(self):
+        ctx = extract_context([])
+        assert ctx.current_topic is None
+        assert ctx.topic_stack == []
+        assert ctx.intent is None
+        assert ctx.depth == "quick"
+
+    def test_non_user_turns_ignored(self):
+        turns = [_turn("AAPL analysis results", role="assistant")]
+        ctx = extract_context(turns)
+        assert ctx.current_topic is None
+        assert ctx.topic_stack == []


### PR DESCRIPTION
## Summary
Implement conversation context using existing SessionLogger (no Redis needed).

## Changes

### src/tracer/conversation/context.py
- ConversationContext — current_topic, topic_stack, intent, depth, last_activity
- extract_context() — parses last 20 turns for tickers/sectors/intent/depth
- resolve_pronoun() — 'this'/'이거' → current_topic, 'previous' → topic_stack[1]
- is_stale() — TTL check (default 10min)

### conversation/engine.py
- Accepts optional SessionLogger
- Reads last 50 turns on each query
- Resolves tickers from context when intent has none

### tests/conversation/test_context.py
- 20 tests: ticker extraction, topic stack order, pronoun resolution, staleness, depth detection

## Tests
263 tests pass, ruff clean.

Closes #34