### PR TITLE
fix: make DataRegistry fallback actually work (closes #58)

### DIFF
--- a/src/tracer/data/registry.py
+++ b/src/tracer/data/registry.py
@@ -42,12 +42,12 @@ class DataRegistry:
             self._adapters[cap].append((name, adapter))
 
     def get(self, capability: ProviderType, name: str | None = None) -> Any:
-        """Get an adapter by capability with fallback, optionally by explicit name.
+        """Get the highest-priority adapter for a capability.
 
-        When *name* is None the method tries each registered adapter in priority
-        order.  If instantiation or a health-check raises, it logs a warning and
-        falls through to the next adapter.  If all fail the last exception is
-        re-raised.
+        This is a simple lookup — it returns the adapter instance without
+        invoking any methods.  For call-level fallback (try the primary
+        adapter, fall through to the next on failure) use
+        :meth:`get_with_fallback` or :meth:`async_get_with_fallback`.
 
         Args:
             capability: The provider protocol to look up.
@@ -69,26 +69,7 @@ class DataRegistry:
                     return adapter
             raise KeyError(f"No adapter named '{name}' for capability {capability.__name__}")
 
-        # Try adapters in priority order with fallback
-        last_exc: Exception | None = None
-        for adapter_name, adapter in adapters:
-            try:
-                # Quick validation: if the adapter is callable, just return it
-                return adapter
-            except Exception as exc:
-                last_exc = exc
-                logger.warning(
-                    "Adapter '%s' for %s failed, trying next: %s",
-                    adapter_name,
-                    capability.__name__,
-                    exc,
-                )
-
-        # All adapters failed — should not reach here since return is inside try,
-        # but kept for safety.
-        if last_exc is not None:
-            raise last_exc
-        raise KeyError(f"No adapter registered for capability {capability.__name__}")
+        return adapters[0][1]
 
     def get_with_fallback(
         self,
@@ -121,6 +102,51 @@ class DataRegistry:
             try:
                 fn = getattr(adapter, method)
                 return fn(*args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                logger.warning(
+                    "Adapter '%s'.%s failed, trying next: %s",
+                    adapter_name,
+                    method,
+                    exc,
+                )
+
+        raise last_exc  # type: ignore[misc]
+
+    async def async_get_with_fallback(
+        self,
+        capability: ProviderType,
+        method: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Call an async *method* on each adapter for *capability* until one succeeds.
+
+        Same as :meth:`get_with_fallback` but awaits the adapter method,
+        making it suitable for the async pipeline tools.
+
+        Args:
+            capability: The provider protocol to look up.
+            method: The async method name to call on the adapter.
+            *args: Positional arguments forwarded to the method.
+            **kwargs: Keyword arguments forwarded to the method.
+
+        Returns:
+            The return value from the first successful adapter call.
+
+        Raises:
+            KeyError: If no adapter is registered for the capability.
+            Exception: The last exception if all adapters fail.
+        """
+        adapters = self._adapters.get(capability)
+        if not adapters:
+            raise KeyError(f"No adapter registered for capability {capability.__name__}")
+
+        last_exc: Exception | None = None
+        for adapter_name, adapter in adapters:
+            try:
+                fn = getattr(adapter, method)
+                return await fn(*args, **kwargs)
             except Exception as exc:
                 last_exc = exc
                 logger.warning(

--- a/src/tracer/tools/pipeline.py
+++ b/src/tracer/tools/pipeline.py
@@ -38,11 +38,12 @@ def _is_stale(fetched_at: datetime, threshold_hours: int = _STALENESS_HOURS) -> 
 async def price_event(ticker: str, registry: DataRegistry) -> ToolResult:
     """Fetch recent price/OHLCV data for a ticker."""
     try:
-        provider: PriceProvider = registry.get(PriceProvider)
         end = date.today()
         start = end - timedelta(days=_DEFAULT_LOOKBACK_DAYS)
-        bars = await provider.get_ohlcv(ticker, start, end)
-        current_price = await provider.get_price(ticker)
+        bars = await registry.async_get_with_fallback(
+            PriceProvider, "get_ohlcv", ticker, start, end
+        )
+        current_price = await registry.async_get_with_fallback(PriceProvider, "get_price", ticker)
         now = datetime.now()
         return ToolResult(
             tool="price_event",
@@ -83,8 +84,9 @@ async def price_event(ticker: str, registry: DataRegistry) -> ToolResult:
 async def news(ticker: str, registry: DataRegistry, limit: int = 10) -> ToolResult:
     """Fetch recent news articles for a ticker."""
     try:
-        provider: NewsProvider = registry.get(NewsProvider)
-        articles = await provider.get_news(ticker, limit=limit)
+        articles = await registry.async_get_with_fallback(
+            NewsProvider, "get_news", ticker, limit=limit
+        )
         now = datetime.now()
         return ToolResult(
             tool="news",
@@ -118,8 +120,9 @@ async def news(ticker: str, registry: DataRegistry, limit: int = 10) -> ToolResu
 async def insider(ticker: str, registry: DataRegistry) -> ToolResult:
     """Fetch insider trading data for a ticker."""
     try:
-        provider: AlternativeProvider = registry.get(AlternativeProvider)
-        records = await provider.get_alternative(ticker, record_type="insider_trades")
+        records = await registry.async_get_with_fallback(
+            AlternativeProvider, "get_alternative", ticker, record_type="insider_trades"
+        )
         now = datetime.now()
         return ToolResult(
             tool="insider",
@@ -155,8 +158,9 @@ async def insider(ticker: str, registry: DataRegistry) -> ToolResult:
 async def macro(indicator: str, registry: DataRegistry) -> ToolResult:
     """Fetch a macroeconomic indicator."""
     try:
-        provider: MacroProvider = registry.get(MacroProvider)
-        data_point = await provider.get_indicator(indicator)
+        data_point = await registry.async_get_with_fallback(
+            MacroProvider, "get_indicator", indicator
+        )
         now = datetime.now()
         return ToolResult(
             tool="macro",
@@ -182,8 +186,9 @@ async def macro(indicator: str, registry: DataRegistry) -> ToolResult:
 async def fundamentals(ticker: str, registry: DataRegistry) -> ToolResult:
     """Fetch fundamental financial data for a ticker."""
     try:
-        provider: FundamentalProvider = registry.get(FundamentalProvider)
-        data = await provider.get_fundamentals(ticker)
+        data = await registry.async_get_with_fallback(
+            FundamentalProvider, "get_fundamentals", ticker
+        )
         now = datetime.now()
         return ToolResult(
             tool="fundamentals",
@@ -214,15 +219,18 @@ async def fundamentals(ticker: str, registry: DataRegistry) -> ToolResult:
 async def cross_market(tickers: list[str], registry: DataRegistry) -> ToolResult:
     """Fetch price data across multiple tickers for cross-market comparison."""
     try:
-        provider: PriceProvider = registry.get(PriceProvider)
         end = date.today()
         start = end - timedelta(days=_DEFAULT_LOOKBACK_DAYS)
         result_data: dict[str, object] = {"period_start": start.isoformat(), "tickers": {}}
 
         for ticker in tickers:
             try:
-                bars = await provider.get_ohlcv(ticker, start, end)
-                current_price = await provider.get_price(ticker)
+                bars = await registry.async_get_with_fallback(
+                    PriceProvider, "get_ohlcv", ticker, start, end
+                )
+                current_price = await registry.async_get_with_fallback(
+                    PriceProvider, "get_price", ticker
+                )
                 result_data["tickers"][ticker] = {  # type: ignore[index]
                     "current_price": current_price,
                     "bars": len(bars),
@@ -366,18 +374,18 @@ async def risk_check(
     Builds a portfolio snapshot from current prices, sizes the proposed
     position using conviction from the thesis, and checks portfolio limits.
     """
-    from tracer.data.providers import PriceProvider
     from tracer.risk.calculator import RiskCalculator
 
     try:
         calculator = RiskCalculator(config)
 
         # Gather current prices for all holdings.
-        price_provider: PriceProvider = registry.get(PriceProvider)
         prices: dict[str, float] = {}
         for holding in config.holdings:
             try:
-                prices[holding.ticker] = await price_provider.get_price(holding.ticker)
+                prices[holding.ticker] = await registry.async_get_with_fallback(
+                    PriceProvider, "get_price", holding.ticker
+                )
             except Exception as exc:
                 logger.warning("Could not fetch price for %s: %s", holding.ticker, exc)
 

--- a/tests/data/test_registry.py
+++ b/tests/data/test_registry.py
@@ -116,6 +116,74 @@ class TestDataRegistry:
         assert registry.get_all(PriceProvider) == []
 
 
+class AsyncFailingPriceAdapter:
+    """Async adapter that always raises."""
+
+    async def get_price(self, ticker: str) -> float:
+        raise RuntimeError("primary down")
+
+    async def get_ohlcv(self, ticker: str, start: date, end: date) -> list[OHLCV]:
+        raise RuntimeError("primary down")
+
+
+class AsyncSucceedingPriceAdapter:
+    """Async adapter that returns a fixed price."""
+
+    async def get_price(self, ticker: str) -> float:
+        return 42.0
+
+    async def get_ohlcv(self, ticker: str, start: date, end: date) -> list[OHLCV]:
+        return []
+
+
+class TestAsyncGetWithFallback:
+    async def test_first_adapter_succeeds(self) -> None:
+        registry = DataRegistry()
+        registry.register("good", AsyncSucceedingPriceAdapter(), [PriceProvider])
+        registry.register("also_good", AsyncSucceedingPriceAdapter(), [PriceProvider])
+        result = await registry.async_get_with_fallback(PriceProvider, "get_price", "AAPL")
+        assert result == 42.0
+
+    async def test_first_fails_second_succeeds(self) -> None:
+        registry = DataRegistry()
+        registry.register("bad", AsyncFailingPriceAdapter(), [PriceProvider])
+        registry.register("good", AsyncSucceedingPriceAdapter(), [PriceProvider])
+        result = await registry.async_get_with_fallback(PriceProvider, "get_price", "AAPL")
+        assert result == 42.0
+
+    async def test_all_fail_raises_last(self) -> None:
+        registry = DataRegistry()
+        registry.register("bad1", AsyncFailingPriceAdapter(), [PriceProvider])
+        registry.register("bad2", AsyncFailingPriceAdapter(), [PriceProvider])
+        with pytest.raises(RuntimeError, match="primary down"):
+            await registry.async_get_with_fallback(PriceProvider, "get_price", "AAPL")
+
+    async def test_missing_capability_raises(self) -> None:
+        registry = DataRegistry()
+        with pytest.raises(KeyError, match="No adapter registered"):
+            await registry.async_get_with_fallback(PriceProvider, "get_price", "AAPL")
+
+    async def test_kwargs_forwarded(self) -> None:
+        class AsyncKwargAdapter:
+            async def fetch(self, ticker: str, period: str = "1d") -> str:
+                return f"{ticker}-{period}"
+
+        registry = DataRegistry()
+        registry.register("kw", AsyncKwargAdapter(), [PriceProvider])
+        result = await registry.async_get_with_fallback(PriceProvider, "fetch", "AAPL", period="5d")
+        assert result == "AAPL-5d"
+
+    async def test_ohlcv_fallback(self) -> None:
+        """Verify fallback works for get_ohlcv with positional args."""
+        registry = DataRegistry()
+        registry.register("bad", AsyncFailingPriceAdapter(), [PriceProvider])
+        registry.register("good", AsyncSucceedingPriceAdapter(), [PriceProvider])
+        result = await registry.async_get_with_fallback(
+            PriceProvider, "get_ohlcv", "AAPL", date.today(), date.today()
+        )
+        assert result == []
+
+
 class FailingPriceAdapter:
     """Adapter that always raises on get_price."""
 

--- a/tests/tools/test_pipeline.py
+++ b/tests/tools/test_pipeline.py
@@ -205,10 +205,13 @@ class TestCrossMarket:
         assert "error" in result.data["tickers"]["MSFT"]
 
     async def test_registry_failure(self) -> None:
-        """If the registry itself fails, the tool returns failure."""
+        """If the registry has no providers, per-ticker errors are recorded."""
         registry = DataRegistry()  # empty — no providers
         result = await cross_market(["AAPL"], registry)
-        assert result.success is False
+        # cross_market handles per-ticker failures gracefully — the outer
+        # result succeeds but each ticker carries an error entry.
+        assert result.success is True
+        assert "error" in result.data["tickers"]["AAPL"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `DataRegistry.get()`의 dead fallback 코드 제거 — `return adapter`는 절대 예외를 던지지 않아 except 블록이 도달 불가능했음
- `async_get_with_fallback()` 메서드 추가 — async 메서드 호출 시 어댑터 간 자동 전환 지원
- 모든 pipeline tool 함수를 `async_get_with_fallback()` 사용으로 변경하여 실제 fallback 동작

## Changes

| 파일 | 변경 |
|------|------|
| `src/tracer/data/registry.py` | `get()` 단순화, `async_get_with_fallback()` 추가 |
| `src/tracer/tools/pipeline.py` | 7개 tool 함수 모두 fallback 경로 사용 |
| `tests/data/test_registry.py` | `TestAsyncGetWithFallback` 6개 테스트 추가 |
| `tests/tools/test_pipeline.py` | `cross_market` 빈 레지스트리 테스트 업데이트 |

## Test plan

- [x] 새 `TestAsyncGetWithFallback` 6개 테스트 통과 (성공/fallback/전부 실패/미등록/kwargs/ohlcv)
- [x] 기존 `TestGetWithFallback` 5개 테스트 통과 (sync 버전 영향 없음)
- [x] 기존 `TestDataRegistry` 8개 테스트 통과 (`get()` 동작 보존)
- [x] pipeline tool 테스트 전체 통과
- [x] pyright 0 errors, ruff clean
- [x] 전체 테스트 270 passed (1 failed — 기존 DuckDB FTS 네트워크 이슈, 무관)

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk