### PR TITLE
refactor: extract shared test fakes into tests/helpers.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ reportMissingTypeStubs = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -3,106 +3,16 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime
 
 import pytest
+from helpers import make_data_registry as _make_data
+from helpers import make_llm_registry as _make_llm
 
 from tracer.agents import Analyst, BaseAgent, Reporter, Researcher, Strategist
-from tracer.data.providers import (
-    OHLCV,
-    FundamentalData,
-    MacroIndicator,
-    NewsArticle,
-)
 from tracer.data.registry import DataRegistry
 from tracer.llm.providers import CompletionRequest, CompletionResponse, Role
 from tracer.llm.registry import LLMRegistry
 from tracer.models import Signal, SignalDirection
-
-# ---------------------------------------------------------------------------
-# Fakes
-# ---------------------------------------------------------------------------
-
-
-class FakeLLM:
-    """Fake LLM provider that returns canned responses."""
-
-    def __init__(self, content: str = "[]") -> None:
-        self.content = content
-        self.calls: list[CompletionRequest] = []
-
-    async def complete(self, request: CompletionRequest) -> CompletionResponse:
-        self.calls.append(request)
-        return CompletionResponse(
-            content=self.content,
-            model="fake",
-            input_tokens=0,
-            output_tokens=0,
-            cost=0.0,
-        )
-
-
-class FakePriceProvider:
-    async def get_price(self, ticker: str) -> float:
-        return 150.0
-
-    async def get_ohlcv(self, ticker: str, start: date, end: date) -> list[OHLCV]:
-        return [OHLCV(date=date(2024, 1, 1), open=100, high=105, low=99, close=102, volume=1000)]
-
-
-class FakeFundamentalProvider:
-    async def get_fundamentals(self, ticker: str) -> FundamentalData:
-        return FundamentalData(
-            ticker=ticker, pe_ratio=20.0, market_cap=1e12, revenue=1e10, earnings=1e9
-        )
-
-
-class FakeMacroProvider:
-    async def get_indicator(self, name: str) -> MacroIndicator:
-        return MacroIndicator(name=name, value=3.5, date=date(2024, 1, 1), source="test", unit="%")
-
-
-class FakeNewsProvider:
-    async def get_news(self, ticker: str, limit: int = 10) -> list[NewsArticle]:
-        return [
-            NewsArticle(
-                title=f"{ticker} surges",
-                source="TestNews",
-                published_at=datetime(2024, 1, 1),
-                url="https://example.com",
-                summary="Stock went up.",
-                sentiment=0.8,
-            )
-        ]
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-def _make_llm(content: str = "[]") -> tuple[LLMRegistry, FakeLLM]:
-    registry = LLMRegistry()
-    fake = FakeLLM(content)
-    registry.register("fake", fake, [Role.RESEARCHER, Role.ANALYST, Role.STRATEGIST, Role.REPORTER])
-    return registry, fake
-
-
-def _make_data() -> DataRegistry:
-    data = DataRegistry()
-    from tracer.data.providers import (
-        FundamentalProvider,
-        MacroProvider,
-        NewsProvider,
-        PriceProvider,
-    )
-
-    data.register("price", FakePriceProvider(), [PriceProvider])
-    data.register("fund", FakeFundamentalProvider(), [FundamentalProvider])
-    data.register("macro", FakeMacroProvider(), [MacroProvider])
-    data.register("news", FakeNewsProvider(), [NewsProvider])
-    return data
-
 
 # ---------------------------------------------------------------------------
 # BaseAgent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Root conftest — makes the tests/ directory importable for shared helpers."""

--- a/tests/conversation/test_context.py
+++ b/tests/conversation/test_context.py
@@ -4,23 +4,14 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+from helpers import make_turn as _turn
+
 from tracer.conversation.context import (
     ConversationContext,
     extract_context,
     is_stale,
     resolve_pronoun,
 )
-from tracer.memory.session_logger import TurnRecord
-
-
-def _turn(content: str, turn: int = 1, role: str = "user", ts: str | None = None) -> TurnRecord:
-    """Helper to build a TurnRecord."""
-    return TurnRecord(
-        turn=turn,
-        role=role,
-        content=content,
-        ts=ts or datetime.now().isoformat(),
-    )
 
 
 class TestExtractTickerFromTurns:

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
 from unittest.mock import AsyncMock, patch
+
+from helpers import failed_result as _failed_result
+from helpers import make_mock_llm_registry as _mock_llm_registry
+from helpers import ok_result as _ok_result
 
 from tracer.config.models import Holding, PortfolioConfig
 from tracer.conversation.engine import (
@@ -18,61 +21,8 @@ from tracer.conversation.engine import (
 )
 from tracer.conversation.intent import Intent, IntentType
 from tracer.data.registry import DataRegistry
-from tracer.llm.providers import CompletionResponse, Role
+from tracer.llm.providers import Role
 from tracer.llm.registry import LLMRegistry
-from tracer.models import ToolResult
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _mock_llm_registry(responses: dict[Role, str | list[str]]) -> LLMRegistry:
-    """Build an LLMRegistry with mock providers that return canned responses.
-
-    If a role maps to a list, responses are returned in order (pop from front).
-    """
-    registry = LLMRegistry()
-    for role, content in responses.items():
-        provider = AsyncMock()
-        if isinstance(content, list):
-            contents = list(content)
-
-            async def _complete(req, _contents=contents):
-                c = _contents.pop(0) if _contents else "{}"
-                return CompletionResponse(
-                    content=c, model="mock", input_tokens=10, output_tokens=5, cost=0.0
-                )
-
-            provider.complete = _complete
-        else:
-            provider.complete.return_value = CompletionResponse(
-                content=content, model="mock", input_tokens=10, output_tokens=5, cost=0.0
-            )
-        registry.register("mock", provider, [role])
-    return registry
-
-
-def _ok_result(tool: str, data: dict | None = None) -> ToolResult:
-    return ToolResult(
-        tool=tool,
-        success=True,
-        data=data or {"sample": "data"},
-        source="test",
-        fetched_at=datetime.now(),
-        is_stale=False,
-    )
-
-
-def _failed_result(tool: str) -> ToolResult:
-    return ToolResult(
-        tool=tool,
-        success=False,
-        data={},
-        source="test",
-        error="test error",
-    )
-
 
 # ---------------------------------------------------------------------------
 # _invoke_tool / _invoke_tools

--- a/tests/conversation/test_intent.py
+++ b/tests/conversation/test_intent.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
+from helpers import make_single_role_registry
 
 from tracer.conversation.intent import (
     INTENT_TOOL_MAP,
@@ -14,7 +15,7 @@ from tracer.conversation.intent import (
     IntentType,
     _extract_tickers,
 )
-from tracer.llm.providers import CompletionResponse, Role
+from tracer.llm.providers import Role
 from tracer.llm.registry import LLMRegistry
 
 # ---------------------------------------------------------------------------
@@ -67,25 +68,10 @@ class TestExtractTickers:
 # ---------------------------------------------------------------------------
 
 
-def _make_registry(response_content: str) -> LLMRegistry:
-    """Build an LLMRegistry with a mock researcher provider."""
-    mock_provider = AsyncMock()
-    mock_provider.complete.return_value = CompletionResponse(
-        content=response_content,
-        model="mock",
-        input_tokens=10,
-        output_tokens=5,
-        cost=0.0,
-    )
-    registry = LLMRegistry()
-    registry.register("mock", mock_provider, [Role.RESEARCHER])
-    return registry
-
-
 class TestIntentParserLLM:
     async def test_event_analysis(self) -> None:
         body = json.dumps({"intent": "event_analysis", "tickers": ["AAPL"]})
-        parser = IntentParser(_make_registry(body))
+        parser = IntentParser(make_single_role_registry(Role.RESEARCHER, body))
         intent = await parser.parse("Why did AAPL spike 5% today?")
         assert intent.intent_type == IntentType.EVENT_ANALYSIS
         assert intent.tickers == ["AAPL"]
@@ -93,33 +79,33 @@ class TestIntentParserLLM:
 
     async def test_deep_dive(self) -> None:
         body = json.dumps({"intent": "deep_dive", "tickers": ["TSMC"]})
-        parser = IntentParser(_make_registry(body))
+        parser = IntentParser(make_single_role_registry(Role.RESEARCHER, body))
         intent = await parser.parse("Full analysis on TSMC")
         assert intent.intent_type == IntentType.DEEP_DIVE
         assert "fundamentals" in intent.tools
 
     async def test_macro_query(self) -> None:
         body = json.dumps({"intent": "macro_query", "tickers": []})
-        parser = IntentParser(_make_registry(body))
+        parser = IntentParser(make_single_role_registry(Role.RESEARCHER, body))
         intent = await parser.parse("Where are we in the rate cycle?")
         assert intent.intent_type == IntentType.MACRO_QUERY
         assert intent.tools == ["macro"]
 
     async def test_alpha_hunt(self) -> None:
         body = json.dumps({"intent": "alpha_hunt", "tickers": []})
-        parser = IntentParser(_make_registry(body))
+        parser = IntentParser(make_single_role_registry(Role.RESEARCHER, body))
         intent = await parser.parse("Where's the hidden alpha right now?")
         assert intent.intent_type == IntentType.ALPHA_HUNT
 
     async def test_cross_market(self) -> None:
         body = json.dumps({"intent": "cross_market", "tickers": []})
-        parser = IntentParser(_make_registry(body))
+        parser = IntentParser(make_single_role_registry(Role.RESEARCHER, body))
         intent = await parser.parse("How does Korea semi data affect US AI stocks?")
         assert intent.intent_type == IntentType.CROSS_MARKET
 
     async def test_follow_up(self) -> None:
         body = json.dumps({"intent": "follow_up", "tickers": []})
-        parser = IntentParser(_make_registry(body))
+        parser = IntentParser(make_single_role_registry(Role.RESEARCHER, body))
         intent = await parser.parse("What about insider trades?")
         assert intent.intent_type == IntentType.FOLLOW_UP
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,227 @@
+"""Shared test fixtures and fake objects.
+
+Centralises fakes, factory functions, and pytest fixtures used across
+multiple test modules.  Import fakes directly; fixtures are discovered
+by pytest automatically.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from unittest.mock import AsyncMock
+
+from tracer.data.providers import (
+    OHLCV,
+    FundamentalData,
+    MacroIndicator,
+    NewsArticle,
+)
+from tracer.data.registry import DataRegistry
+from tracer.llm.providers import CompletionRequest, CompletionResponse, Role
+from tracer.llm.registry import LLMRegistry
+from tracer.memory.session_logger import TurnRecord
+from tracer.models import ToolResult
+
+# ---------------------------------------------------------------------------
+# Fake LLM providers
+# ---------------------------------------------------------------------------
+
+
+class FakeLLM:
+    """Fake LLM provider that returns canned responses.
+
+    Tracks all calls for assertion in tests.
+    """
+
+    def __init__(self, content: str = "[]") -> None:
+        self.content = content
+        self.calls: list[CompletionRequest] = []
+
+    async def complete(self, request: CompletionRequest) -> CompletionResponse:
+        self.calls.append(request)
+        return CompletionResponse(
+            content=self.content,
+            model="fake",
+            input_tokens=0,
+            output_tokens=0,
+            cost=0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fake data providers
+# ---------------------------------------------------------------------------
+
+
+class FakePriceProvider:
+    """Async fake implementing PriceProvider protocol."""
+
+    async def get_price(self, ticker: str) -> float:
+        return 150.0
+
+    async def get_ohlcv(self, ticker: str, start: date, end: date) -> list[OHLCV]:
+        return [OHLCV(date=date(2024, 1, 1), open=100, high=105, low=99, close=102, volume=1000)]
+
+
+class FakeFundamentalProvider:
+    """Async fake implementing FundamentalProvider protocol."""
+
+    async def get_fundamentals(self, ticker: str) -> FundamentalData:
+        return FundamentalData(
+            ticker=ticker, pe_ratio=20.0, market_cap=1e12, revenue=1e10, earnings=1e9
+        )
+
+
+class FakeMacroProvider:
+    """Async fake implementing MacroProvider protocol."""
+
+    async def get_indicator(self, name: str) -> MacroIndicator:
+        return MacroIndicator(name=name, value=3.5, date=date(2024, 1, 1), source="test", unit="%")
+
+
+class FakeNewsProvider:
+    """Async fake implementing NewsProvider protocol."""
+
+    async def get_news(self, ticker: str, limit: int = 10) -> list[NewsArticle]:
+        return [
+            NewsArticle(
+                title=f"{ticker} surges",
+                source="TestNews",
+                published_at=datetime(2024, 1, 1),
+                url="https://example.com",
+                summary="Stock went up.",
+                sentiment=0.8,
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Factory functions
+# ---------------------------------------------------------------------------
+
+
+def make_llm_registry(content: str = "[]") -> tuple[LLMRegistry, FakeLLM]:
+    """Create an LLMRegistry with a FakeLLM registered for all roles."""
+    registry = LLMRegistry()
+    fake = FakeLLM(content)
+    registry.register("fake", fake, [Role.RESEARCHER, Role.ANALYST, Role.STRATEGIST, Role.REPORTER])
+    return registry, fake
+
+
+def make_data_registry() -> DataRegistry:
+    """Create a DataRegistry with all fake providers registered."""
+    from tracer.data.providers import (
+        FundamentalProvider,
+        MacroProvider,
+        NewsProvider,
+        PriceProvider,
+    )
+
+    data = DataRegistry()
+    data.register("price", FakePriceProvider(), [PriceProvider])
+    data.register("fund", FakeFundamentalProvider(), [FundamentalProvider])
+    data.register("macro", FakeMacroProvider(), [MacroProvider])
+    data.register("news", FakeNewsProvider(), [NewsProvider])
+    return data
+
+
+def make_mock_llm_registry(responses: dict[Role, str | list[str]]) -> LLMRegistry:
+    """Build an LLMRegistry with AsyncMock providers returning canned responses.
+
+    If a role maps to a list, responses are returned in sequence.
+    """
+    registry = LLMRegistry()
+    for role, content in responses.items():
+        provider = AsyncMock()
+        if isinstance(content, list):
+            contents = list(content)
+
+            async def _complete(req, _contents=contents):  # type: ignore[no-untyped-def]
+                c = _contents.pop(0) if _contents else "{}"
+                return CompletionResponse(
+                    content=c, model="mock", input_tokens=10, output_tokens=5, cost=0.0
+                )
+
+            provider.complete = _complete
+        else:
+            provider.complete.return_value = CompletionResponse(
+                content=content, model="mock", input_tokens=10, output_tokens=5, cost=0.0
+            )
+        registry.register("mock", provider, [role])
+    return registry
+
+
+def make_single_role_registry(role: Role, response_content: str) -> LLMRegistry:
+    """Build an LLMRegistry with one mock provider for a single role."""
+    mock_provider = AsyncMock()
+    mock_provider.complete.return_value = CompletionResponse(
+        content=response_content,
+        model="mock",
+        input_tokens=10,
+        output_tokens=5,
+        cost=0.0,
+    )
+    registry = LLMRegistry()
+    registry.register("mock", mock_provider, [role])
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# ToolResult helpers
+# ---------------------------------------------------------------------------
+
+
+def ok_result(tool: str, data: dict | None = None) -> ToolResult:
+    """Create a successful ToolResult for testing."""
+    return ToolResult(
+        tool=tool,
+        success=True,
+        data=data or {"sample": "data"},
+        source="test",
+        fetched_at=datetime.now(),
+        is_stale=False,
+    )
+
+
+def failed_result(tool: str) -> ToolResult:
+    """Create a failed ToolResult for testing."""
+    return ToolResult(
+        tool=tool,
+        success=False,
+        data={},
+        source="test",
+        error="test error",
+    )
+
+
+def sample_analysis_results() -> list[ToolResult]:
+    """Create sample analysis results for trade thesis tests."""
+    return [
+        ToolResult(
+            tool="price_event",
+            success=True,
+            data={"ticker": "AAPL", "current_price": 185.0},
+            source="PriceProvider",
+        ),
+        ToolResult(
+            tool="fundamentals",
+            success=True,
+            data={"ticker": "AAPL", "pe_ratio": 28.5},
+            source="FundamentalProvider",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# TurnRecord helper
+# ---------------------------------------------------------------------------
+
+
+def make_turn(content: str, turn: int = 1, role: str = "user", ts: str | None = None) -> TurnRecord:
+    """Build a TurnRecord for context tests."""
+    return TurnRecord(
+        turn=turn,
+        role=role,
+        content=content,
+        ts=ts or datetime.now().isoformat(),
+    )

--- a/tests/tools/test_trade_thesis.py
+++ b/tests/tools/test_trade_thesis.py
@@ -6,44 +6,12 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
+from helpers import make_single_role_registry, sample_analysis_results
 
-from tracer.llm.providers import CompletionResponse, Role
+from tracer.llm.providers import Role
 from tracer.llm.registry import LLMRegistry
-from tracer.models import ToolResult, TradeThesis
+from tracer.models import TradeThesis
 from tracer.tools.pipeline import trade_thesis
-
-
-def _llm_registry(response_content: str) -> LLMRegistry:
-    """Build an LLMRegistry with a mock strategist returning the given content."""
-    mock_provider = AsyncMock()
-    mock_provider.complete.return_value = CompletionResponse(
-        content=response_content,
-        model="mock",
-        input_tokens=0,
-        output_tokens=0,
-        cost=0.0,
-    )
-    registry = LLMRegistry()
-    registry.register("mock", mock_provider, [Role.STRATEGIST])
-    return registry
-
-
-def _sample_analysis_results() -> list[ToolResult]:
-    return [
-        ToolResult(
-            tool="price_event",
-            success=True,
-            data={"ticker": "AAPL", "current_price": 185.0},
-            source="PriceProvider",
-        ),
-        ToolResult(
-            tool="fundamentals",
-            success=True,
-            data={"ticker": "AAPL", "pe_ratio": 28.5},
-            source="FundamentalProvider",
-        ),
-    ]
-
 
 _VALID_LLM_RESPONSE = json.dumps(
     {
@@ -60,8 +28,8 @@ _VALID_LLM_RESPONSE = json.dumps(
 
 class TestTradeThesis:
     async def test_success(self) -> None:
-        registry = _llm_registry(_VALID_LLM_RESPONSE)
-        result = await trade_thesis("AAPL", _sample_analysis_results(), registry)
+        registry = make_single_role_registry(Role.STRATEGIST, _VALID_LLM_RESPONSE)
+        result = await trade_thesis("AAPL", sample_analysis_results(), registry)
 
         assert result.success is True
         assert result.tool == "trade_thesis"
@@ -76,8 +44,8 @@ class TestTradeThesis:
         assert isinstance(thesis["summary"], str)
 
     async def test_risk_reward_ratio_computed(self) -> None:
-        registry = _llm_registry(_VALID_LLM_RESPONSE)
-        result = await trade_thesis("AAPL", _sample_analysis_results(), registry)
+        registry = make_single_role_registry(Role.STRATEGIST, _VALID_LLM_RESPONSE)
+        result = await trade_thesis("AAPL", sample_analysis_results(), registry)
 
         assert result.success is True
         thesis = result.data["thesis"]
@@ -98,24 +66,26 @@ class TestTradeThesis:
                 "summary": "test",
             }
         )
-        registry = _llm_registry(bad_response)
-        result = await trade_thesis("AAPL", _sample_analysis_results(), registry)
+        registry = make_single_role_registry(Role.STRATEGIST, bad_response)
+        result = await trade_thesis("AAPL", sample_analysis_results(), registry)
 
         assert result.success is False
         assert result.error is not None
 
     async def test_invalid_json_response(self) -> None:
         """Non-JSON LLM response should return failure."""
-        registry = _llm_registry("This is not JSON at all")
-        result = await trade_thesis("AAPL", _sample_analysis_results(), registry)
+        registry = make_single_role_registry(Role.STRATEGIST, "This is not JSON at all")
+        result = await trade_thesis("AAPL", sample_analysis_results(), registry)
 
         assert result.success is False
         assert "Failed to parse" in (result.error or "")
 
     async def test_missing_keys_in_response(self) -> None:
         """Missing required keys should return failure."""
-        registry = _llm_registry(json.dumps({"entry_zone": [180, 185]}))
-        result = await trade_thesis("AAPL", _sample_analysis_results(), registry)
+        registry = make_single_role_registry(
+            Role.STRATEGIST, json.dumps({"entry_zone": [180, 185]})
+        )
+        result = await trade_thesis("AAPL", sample_analysis_results(), registry)
 
         assert result.success is False
 
@@ -126,7 +96,7 @@ class TestTradeThesis:
         registry = LLMRegistry()
         registry.register("mock", mock_provider, [Role.STRATEGIST])
 
-        result = await trade_thesis("AAPL", _sample_analysis_results(), registry)
+        result = await trade_thesis("AAPL", sample_analysis_results(), registry)
 
         assert result.success is False
         assert result.error is not None
@@ -144,15 +114,15 @@ class TestTradeThesis:
                 "summary": "Moderate outlook.",
             }
         )
-        registry = _llm_registry(response)
-        result = await trade_thesis("AAPL", _sample_analysis_results(), registry)
+        registry = make_single_role_registry(Role.STRATEGIST, response)
+        result = await trade_thesis("AAPL", sample_analysis_results(), registry)
 
         assert result.success is True
         assert result.data["thesis"]["catalyst_date"] is None
 
     async def test_empty_analysis_results(self) -> None:
         """Should work even with no prior analysis results."""
-        registry = _llm_registry(_VALID_LLM_RESPONSE)
+        registry = make_single_role_registry(Role.STRATEGIST, _VALID_LLM_RESPONSE)
         result = await trade_thesis("AAPL", [], registry)
 
         assert result.success is True


### PR DESCRIPTION
## Summary

- 6개 테스트 파일에 중복 정의되어 있던 fake 객체와 팩토리 함수를 `tests/helpers.py`로 추출
- `FakeLLM`, `FakePriceProvider`, `FakeFundamentalProvider`, `FakeMacroProvider`, `FakeNewsProvider` 통합
- `make_llm_registry()`, `make_data_registry()`, `make_mock_llm_registry()`, `make_single_role_registry()` 팩토리 함수 통합
- `ok_result()`, `failed_result()`, `sample_analysis_results()`, `make_turn()` 헬퍼 통합
- ~120줄의 중복 코드 제거

## Changes

| 파일 | 변경 |
|------|------|
| `tests/helpers.py` | **신규** — 공유 fakes, factories, helpers |
| `tests/conftest.py` | **신규** — 빈 conftest (향후 pytest fixture 추가용) |
| `tests/agents/test_agents.py` | 로컬 fake 제거, helpers import |
| `tests/conversation/test_engine.py` | 로컬 helper 제거, helpers import |
| `tests/conversation/test_intent.py` | `_make_registry` 제거, helpers import |
| `tests/conversation/test_context.py` | `_turn` 제거, helpers import |
| `tests/tools/test_trade_thesis.py` | `_llm_registry`, `_sample_analysis_results` 제거, helpers import |
| `pyproject.toml` | pythonpath에 "tests" 추가 |

## Test plan

- [x] 270 passed (기존 DuckDB FTS 네트워크 이슈 2개 제외)
- [x] ruff check/format clean
- [x] pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk