### PR TITLE
feat: multi-ticker comparison analysis (closes #50)

### DIFF
--- a/src/tracer/conversation/__init__.py
+++ b/src/tracer/conversation/__init__.py
@@ -1,6 +1,7 @@
 from tracer.conversation.engine import (
     AnalysisLoop,
     AnalysisResult,
+    ComparisonSynthesizer,
     ConversationEngine,
     EngineResponse,
     ResponseSynthesizer,
@@ -15,6 +16,7 @@ from tracer.conversation.intent import (
 __all__ = [
     "AnalysisLoop",
     "AnalysisResult",
+    "ComparisonSynthesizer",
     "ConversationEngine",
     "EngineResponse",
     "INTENT_TOOL_MAP",

--- a/src/tracer/conversation/engine.py
+++ b/src/tracer/conversation/engine.py
@@ -14,7 +14,7 @@ from datetime import datetime
 
 from tracer.config.models import PortfolioConfig
 from tracer.conversation.context import ConversationContext, extract_context, resolve_pronoun
-from tracer.conversation.intent import Intent, IntentParser
+from tracer.conversation.intent import Intent, IntentParser, IntentType
 from tracer.data.registry import DataRegistry, build_registry
 from tracer.llm.providers import CompletionRequest, CompletionResponse, Message, Role
 from tracer.llm.registry import LLMRegistry
@@ -300,6 +300,77 @@ class ResponseSynthesizer:
         return "\n".join(lines)
 
 
+class ComparisonSynthesizer:
+    """Synthesizes a side-by-side comparison for multiple tickers."""
+
+    def __init__(self, llm_registry: LLMRegistry) -> None:
+        self._llm = llm_registry
+
+    async def synthesize(
+        self, intent: Intent, per_ticker_results: dict[str, list[ToolResult]]
+    ) -> str:
+        """Generate a comparative response table with verdict."""
+        evidence_sections: list[str] = []
+        for ticker, results in per_ticker_results.items():
+            successful = [r for r in results if r.success]
+            evidence_sections.append(f"--- {ticker} ---\n{_format_evidence(successful)}")
+        combined_evidence = "\n\n".join(evidence_sections)
+        tickers_str = ", ".join(intent.tickers)
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        header = "| Metric | " + " | ".join(intent.tickers) + " |"
+        separator = "|" + "---|" * (len(intent.tickers) + 1)
+
+        system = (
+            "You are a senior financial analyst. Compare the given tickers "
+            "side-by-side.\n\n"
+            "Use this EXACT format:\n"
+            f"[COMPARISON: {tickers_str} — {today}]\n\n"
+            f"{header}\n{separator}\n"
+            "| Price | ... |\n"
+            "| PE Ratio | ... |\n"
+            "| Revenue Growth | ... |\n"
+            "| Conviction | ... |\n"
+            "(add more rows as the data supports)\n\n"
+            "VERDICT\n"
+            "{{comparative analysis: which ticker is stronger and why, "
+            "1-3 sentences}}"
+        )
+        user_msg = f"Query: {intent.raw_query}\n\nEvidence per ticker:\n{combined_evidence}"
+
+        try:
+            provider = self._llm.get(Role.STRATEGIST)
+            response = await provider.complete(
+                CompletionRequest(
+                    messages=[
+                        Message(role="system", content=system),
+                        Message(role="user", content=user_msg),
+                    ],
+                    max_tokens=2048,
+                    temperature=0.2,
+                )
+            )
+            return response.content
+        except Exception:
+            logger.warning("ComparisonSynthesizer failed, returning fallback", exc_info=True)
+            return self._fallback_response(intent, per_ticker_results)
+
+    def _fallback_response(
+        self, intent: Intent, per_ticker_results: dict[str, list[ToolResult]]
+    ) -> str:
+        lines = [f"[COMPARISON: {', '.join(intent.tickers)}]"]
+        lines.append(f"Query: {intent.raw_query}")
+        lines.append("")
+        for ticker, results in per_ticker_results.items():
+            lines.append(f"  {ticker}:")
+            for r in results:
+                status = "OK" if r.success else f"FAILED ({r.error})"
+                lines.append(f"    [{r.tool}] {status}")
+        lines.append("")
+        lines.append("(Full comparison unavailable — LLM error)")
+        return "\n".join(lines)
+
+
 class ConversationEngine:
     """Top-level orchestrator that wires together the conversational pipeline.
 
@@ -327,6 +398,7 @@ class ConversationEngine:
             confidence_threshold=confidence_threshold,
         )
         self._synthesizer = ResponseSynthesizer(llm_registry)
+        self._comparison_synthesizer = ComparisonSynthesizer(llm_registry)
         self._data = data_registry
         self._portfolio_config = portfolio_config or PortfolioConfig()
         self._history: list[dict] = []
@@ -368,10 +440,31 @@ class ConversationEngine:
             intent.tools,
         )
 
-        # 2. Invoke initial pipeline tools.
+        # 2. Comparison branch: per-ticker analysis + comparison table.
+        if intent.intent_type == IntentType.COMPARISON and len(intent.tickers) >= 2:
+            single_intents = [
+                Intent(
+                    intent_type=IntentType.COMPARISON,
+                    tickers=[ticker],
+                    tools=intent.tools,
+                    raw_query=intent.raw_query,
+                )
+                for ticker in intent.tickers
+            ]
+            gathered = await asyncio.gather(
+                *[_invoke_tools(si.tools, si, self._data) for si in single_intents]
+            )
+            per_ticker_results: dict[str, list[ToolResult]] = dict(zip(intent.tickers, gathered))
+            all_results = [r for results in per_ticker_results.values() for r in results]
+            analysis = AnalysisResult(results=all_results, confidence=0.7, iterations=1)
+            text = await self._comparison_synthesizer.synthesize(intent, per_ticker_results)
+            self._history.append({"role": "assistant", "content": text})
+            return EngineResponse(text=text, intent=intent, analysis=analysis)
+
+        # 3. Invoke initial pipeline tools (standard path).
         initial_results = await _invoke_tools(intent.tools, intent, self._data)
 
-        # 3. Run analysis loop.
+        # 4. Run analysis loop.
         analysis = await self._analysis_loop.run(intent, initial_results)
         logger.info(
             "Analysis complete: confidence=%.2f iterations=%d",

--- a/src/tracer/conversation/intent.py
+++ b/src/tracer/conversation/intent.py
@@ -26,6 +26,7 @@ class IntentType(str, Enum):
     MACRO_QUERY = "macro_query"
     CROSS_MARKET = "cross_market"
     FOLLOW_UP = "follow_up"
+    COMPARISON = "comparison"
 
 
 # Which pipeline tools each intent invokes by default.
@@ -42,6 +43,7 @@ INTENT_TOOL_MAP: dict[IntentType, list[str]] = {
     IntentType.MACRO_QUERY: ["macro"],
     IntentType.CROSS_MARKET: ["cross_market", "macro", "price_event"],
     IntentType.FOLLOW_UP: [],  # resolved from session context
+    IntentType.COMPARISON: ["price_event", "fundamentals", "news"],
 }
 
 
@@ -63,7 +65,8 @@ class Intent:
 _SYSTEM_PROMPT = """\
 You are a query classifier for a financial analysis system.
 Given a user query, return a JSON object with:
-- "intent": one of event_analysis, deep_dive, alpha_hunt, macro_query, cross_market, follow_up
+- "intent": one of event_analysis, deep_dive, alpha_hunt, macro_query, \
+cross_market, follow_up, comparison
 - "tickers": list of stock tickers mentioned (uppercase, empty list if none)
 
 Rules:
@@ -73,6 +76,7 @@ Rules:
 - Questions about rates, inflation, GDP, macro → macro_query
 - Questions relating two markets/regions → cross_market
 - Short follow-ups referencing prior context → follow_up
+- "Compare X and Y", "X vs Y" (multiple tickers) → comparison
 
 Return ONLY valid JSON, no explanation."""
 
@@ -122,6 +126,10 @@ class IntentParser:
         # Extract uppercase tickers (simple heuristic: 1-5 letter uppercase words).
         tickers = _extract_tickers(query)
 
+        # Comparison must be checked first — "Compare AAPL spike" should be comparison.
+        if len(tickers) >= 2 and any(w in q for w in ("compare", " vs ", "versus")):
+            return Intent(IntentType.COMPARISON, tickers=tickers, raw_query=query)
+
         if any(w in q for w in ("spike", "drop", "crash", "move", "why did", "fell", "rose")):
             return Intent(IntentType.EVENT_ANALYSIS, tickers=tickers, raw_query=query)
         if any(w in q for w in ("full analysis", "deep dive", "tell me about", "analyze")):
@@ -132,6 +140,8 @@ class IntentParser:
             return Intent(IntentType.MACRO_QUERY, tickers=tickers, raw_query=query)
         if any(w in q for w in ("cross", "affect", "impact", "correlation", "relationship")):
             return Intent(IntentType.CROSS_MARKET, tickers=tickers, raw_query=query)
+        if any(w in q for w in ("compare", " vs ", "versus")):
+            return Intent(IntentType.COMPARISON, tickers=tickers, raw_query=query)
 
         # Default to follow_up for short/ambiguous queries.
         return Intent(IntentType.FOLLOW_UP, tickers=tickers, raw_query=query)

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -13,6 +13,7 @@ from tracer.config.models import Holding, PortfolioConfig
 from tracer.conversation.engine import (
     AnalysisLoop,
     AnalysisResult,
+    ComparisonSynthesizer,
     ConversationEngine,
     EngineResponse,
     ResponseSynthesizer,
@@ -440,3 +441,105 @@ class TestConversationEngine:
 
         # With threshold 0.9 and confidence 0.5, it should have low confidence.
         assert response.analysis.confidence < 0.9
+
+
+# ---------------------------------------------------------------------------
+# ComparisonSynthesizer
+# ---------------------------------------------------------------------------
+
+
+class TestComparisonSynthesizer:
+    async def test_synthesize_calls_strategist(self) -> None:
+        llm = _mock_llm_registry(
+            {
+                Role.STRATEGIST: (
+                    "[COMPARISON: AAPL, MSFT]\n"
+                    "| Metric | AAPL | MSFT |\n"
+                    "|---|---|---|\n"
+                    "| Price | 180 | 350 |\n\n"
+                    "VERDICT\nMSFT is stronger."
+                ),
+            }
+        )
+        synth = ComparisonSynthesizer(llm)
+        intent = Intent(
+            IntentType.COMPARISON,
+            tickers=["AAPL", "MSFT"],
+            raw_query="Compare AAPL and MSFT",
+        )
+        per_ticker = {
+            "AAPL": [_ok_result("price_event"), _ok_result("fundamentals")],
+            "MSFT": [_ok_result("price_event"), _ok_result("fundamentals")],
+        }
+
+        text = await synth.synthesize(intent, per_ticker)
+        assert "COMPARISON" in text
+        assert "AAPL" in text
+        assert "MSFT" in text
+
+    async def test_fallback_on_llm_failure(self) -> None:
+        provider = AsyncMock()
+        provider.complete.side_effect = RuntimeError("LLM down")
+        llm = LLMRegistry()
+        llm.register("mock", provider, [Role.STRATEGIST])
+
+        synth = ComparisonSynthesizer(llm)
+        intent = Intent(IntentType.COMPARISON, tickers=["AAPL", "MSFT"], raw_query="AAPL vs MSFT")
+        per_ticker = {
+            "AAPL": [_ok_result("price_event")],
+            "MSFT": [_ok_result("price_event"), _failed_result("fundamentals")],
+        }
+
+        text = await synth.synthesize(intent, per_ticker)
+        assert "COMPARISON" in text
+        assert "LLM error" in text
+
+
+# ---------------------------------------------------------------------------
+# ConversationEngine — comparison path
+# ---------------------------------------------------------------------------
+
+
+class TestConversationEngineComparison:
+    async def test_comparison_pipeline(self) -> None:
+        intent_resp = json.dumps({"intent": "comparison", "tickers": ["AAPL", "MSFT"]})
+        comparison_resp = (
+            "[COMPARISON: AAPL, MSFT]\n"
+            "| Metric | AAPL | MSFT |\n"
+            "|---|---|---|\n"
+            "| Price | 180 | 350 |\n\n"
+            "VERDICT\nMSFT is stronger."
+        )
+
+        llm = _mock_llm_registry({Role.RESEARCHER: intent_resp, Role.STRATEGIST: comparison_resp})
+        engine = ConversationEngine(llm, DataRegistry())
+
+        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+            mock_invoke.return_value = [_ok_result("price_event"), _ok_result("fundamentals")]
+            response = await engine.query("Compare AAPL and MSFT")
+
+        assert isinstance(response, EngineResponse)
+        assert response.intent.intent_type == IntentType.COMPARISON
+        assert "COMPARISON" in response.text
+        assert mock_invoke.call_count == 2  # once per ticker
+
+    async def test_single_ticker_comparison_falls_through(self) -> None:
+        intent_resp = json.dumps({"intent": "comparison", "tickers": ["AAPL"]})
+        analysis_resp = json.dumps({"confidence": 0.85, "missing_tools": []})
+        synth_resp = "[ANALYSIS: AAPL]\nStandard response"
+
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: intent_resp,
+                Role.ANALYST: analysis_resp,
+                Role.STRATEGIST: synth_resp,
+            }
+        )
+        engine = ConversationEngine(llm, DataRegistry())
+
+        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+            mock_invoke.return_value = [_ok_result("price_event")]
+            response = await engine.query("Compare AAPL")
+
+        assert response.intent.intent_type == IntentType.COMPARISON
+        assert "ANALYSIS" in response.text

--- a/tests/conversation/test_intent.py
+++ b/tests/conversation/test_intent.py
@@ -164,6 +164,30 @@ class TestIntentParserKeywordFallback:
         intent = await parser.parse("How does oil affect airlines?")
         assert intent.intent_type == IntentType.CROSS_MARKET
 
+    async def test_keyword_comparison_compare(self) -> None:
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = RuntimeError("fail")
+        registry = LLMRegistry()
+        registry.register("mock", mock_provider, [Role.RESEARCHER])
+
+        parser = IntentParser(registry)
+        intent = await parser.parse("Compare AAPL and MSFT")
+        assert intent.intent_type == IntentType.COMPARISON
+        assert "AAPL" in intent.tickers
+        assert "MSFT" in intent.tickers
+
+    async def test_keyword_comparison_vs(self) -> None:
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = RuntimeError("fail")
+        registry = LLMRegistry()
+        registry.register("mock", mock_provider, [Role.RESEARCHER])
+
+        parser = IntentParser(registry)
+        intent = await parser.parse("AAPL vs TSLA")
+        assert intent.intent_type == IntentType.COMPARISON
+        assert "AAPL" in intent.tickers
+        assert "TSLA" in intent.tickers
+
     async def test_keyword_fallback_default(self) -> None:
         mock_provider = AsyncMock()
         mock_provider.complete.side_effect = RuntimeError("fail")


### PR DESCRIPTION
## Summary

Re-implements #57 on latest main (closes #50). Adds `COMPARISON` intent type and `ComparisonSynthesizer` for side-by-side ticker comparison.

Supersedes #57 which was based on stale main.

## Changes

| 파일 | 변경 |
|------|------|
| `src/tracer/conversation/intent.py` | `IntentType.COMPARISON`, system prompt, keyword fallback |
| `src/tracer/conversation/engine.py` | `ComparisonSynthesizer` 클래스, comparison 분기 |
| `src/tracer/conversation/__init__.py` | export 추가 |
| `tests/conversation/test_engine.py` | ComparisonSynthesizer + engine comparison path 테스트 4개 |
| `tests/conversation/test_intent.py` | comparison keyword 테스트 2개 |

## Test plan

- [x] 276 passed (기존 270 + 새 6개)
- [x] ruff check/format clean
- [x] pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk