### PR TITLE
feat: implement drawdown tracking in RiskCalculator (closes #67)

### DIFF
--- a/src/tracer/risk/calculator.py
+++ b/src/tracer/risk/calculator.py
@@ -55,8 +55,9 @@ def get_sector(ticker: str) -> str:
 class RiskCalculator:
     """Builds portfolio snapshots and performs risk calculations."""
 
-    def __init__(self, config: PortfolioConfig) -> None:
+    def __init__(self, config: PortfolioConfig, *, peak_value: float = 0.0) -> None:
         self._config = config
+        self._peak_value = peak_value
 
     def build_snapshot(self, prices: dict[str, float]) -> PortfolioSnapshot:
         """Build a portfolio snapshot from current prices.
@@ -208,18 +209,50 @@ class RiskCalculator:
                 total += h.weight_pct
         return total
 
+    def update_peak(self, current_value: float) -> float:
+        """Update and return the peak portfolio value.
+
+        Call this each time a new snapshot is built.  The peak is tracked
+        in-memory on the calculator instance.
+        """
+        if current_value > self._peak_value:
+            self._peak_value = current_value
+        return self._peak_value
+
+    @property
+    def peak_value(self) -> float:
+        """Current recorded peak value."""
+        return self._peak_value
+
+    def compute_drawdown(self, current_value: float) -> float:
+        """Compute current drawdown as a percentage.
+
+        Returns 0.0 when peak is zero or current value exceeds peak.
+        """
+        if self._peak_value <= 0 or current_value >= self._peak_value:
+            return 0.0
+        return (self._peak_value - current_value) / self._peak_value * 100.0
+
     def assess(self, prices: dict[str, float]) -> RiskAssessment:
         """Run a full risk assessment.
 
-        Convenience method that builds snapshot, exposure, and checks limits.
+        Convenience method that builds snapshot, exposure, checks limits,
+        and evaluates drawdown.
         """
         snapshot = self.build_snapshot(prices)
         exposure = self.build_exposure(snapshot)
         breached = self.check_limits(snapshot, exposure)
 
+        self.update_peak(snapshot.total_value)
+        drawdown_pct = self.compute_drawdown(snapshot.total_value)
+        alert_threshold = self._config.limits.max_drawdown_alert_pct
+        drawdown_alert = drawdown_pct > alert_threshold
+
         return RiskAssessment(
             snapshot=snapshot,
             exposure=exposure,
             limits_breached=breached,
-            max_drawdown_alert=False,  # TODO: implement drawdown tracking
+            max_drawdown_alert=drawdown_alert,
+            current_drawdown_pct=round(drawdown_pct, 2),
+            peak_value=round(self._peak_value, 2),
         )

--- a/src/tracer/risk/models.py
+++ b/src/tracer/risk/models.py
@@ -52,3 +52,5 @@ class RiskAssessment(BaseModel):
     exposure: ExposureBreakdown
     limits_breached: list[str] = Field(default_factory=list)
     max_drawdown_alert: bool = False
+    current_drawdown_pct: float = 0.0
+    peak_value: float = 0.0

--- a/tests/risk/test_calculator.py
+++ b/tests/risk/test_calculator.py
@@ -308,3 +308,66 @@ class TestGetSector:
 
     def test_case_insensitive(self) -> None:
         assert get_sector("aapl") == "Technology"
+
+
+# ---------------------------------------------------------------------------
+# Drawdown tracking
+# ---------------------------------------------------------------------------
+
+
+class TestDrawdownTracking:
+    def test_update_peak(self, calculator: RiskCalculator) -> None:
+        assert calculator.peak_value == 0.0
+        calculator.update_peak(100_000.0)
+        assert calculator.peak_value == 100_000.0
+        calculator.update_peak(90_000.0)  # lower — should not change
+        assert calculator.peak_value == 100_000.0
+        calculator.update_peak(110_000.0)  # new high
+        assert calculator.peak_value == 110_000.0
+
+    def test_compute_drawdown_at_peak(self, calculator: RiskCalculator) -> None:
+        calculator.update_peak(100_000.0)
+        assert calculator.compute_drawdown(100_000.0) == 0.0
+
+    def test_compute_drawdown_below_peak(self, calculator: RiskCalculator) -> None:
+        calculator.update_peak(100_000.0)
+        dd = calculator.compute_drawdown(90_000.0)
+        assert dd == pytest.approx(10.0)
+
+    def test_compute_drawdown_above_peak(self, calculator: RiskCalculator) -> None:
+        calculator.update_peak(100_000.0)
+        assert calculator.compute_drawdown(110_000.0) == 0.0
+
+    def test_compute_drawdown_zero_peak(self, calculator: RiskCalculator) -> None:
+        assert calculator.compute_drawdown(50_000.0) == 0.0
+
+    def test_assess_drawdown_no_alert(self, portfolio_config: PortfolioConfig) -> None:
+        """Drawdown under threshold should not trigger alert."""
+        # AAPL=100*180=18000, MSFT=50*350=17500, JPM=200*160=32000 → total=67500
+        calc = RiskCalculator(portfolio_config, peak_value=70_000.0)
+        prices = {"AAPL": 180.0, "MSFT": 350.0, "JPM": 160.0}
+        result = calc.assess(prices)
+        # Drawdown is (70000 - 67500) / 70000 ≈ 3.6% < 10% threshold
+        assert result.max_drawdown_alert is False
+        assert result.current_drawdown_pct < 10.0
+        assert result.peak_value == 70_000.0
+
+    def test_assess_drawdown_triggers_alert(self, portfolio_config: PortfolioConfig) -> None:
+        """Drawdown exceeding threshold should trigger alert."""
+        # total ≈ 67500, peak=100000 → drawdown ≈ 32.5% > 10%
+        calc = RiskCalculator(portfolio_config, peak_value=100_000.0)
+        prices = {"AAPL": 180.0, "MSFT": 350.0, "JPM": 160.0}
+        result = calc.assess(prices)
+        assert result.max_drawdown_alert is True
+        assert result.current_drawdown_pct > 10.0
+        assert result.peak_value == 100_000.0
+
+    def test_assess_updates_peak_on_new_high(self, portfolio_config: PortfolioConfig) -> None:
+        """If current value exceeds peak, peak should update."""
+        # total ≈ 67500, peak=50000 → new high
+        calc = RiskCalculator(portfolio_config, peak_value=50_000.0)
+        prices = {"AAPL": 180.0, "MSFT": 350.0, "JPM": 160.0}
+        result = calc.assess(prices)
+        assert result.peak_value == result.snapshot.total_value
+        assert result.current_drawdown_pct == 0.0
+        assert result.max_drawdown_alert is False


### PR DESCRIPTION
## Summary

RiskCalculator에 drawdown 추적 기능을 구현합니다 (closes #67).

기존에 `max_drawdown_alert=False # TODO` 주석만 있던 부분을 실제 로직으로 대체합니다.

## Changes

| 파일 | 변경 |
|------|------|
| `src/tracer/risk/models.py` | `RiskAssessment`에 `current_drawdown_pct`, `peak_value` 필드 추가 |
| `src/tracer/risk/calculator.py` | `update_peak()`, `compute_drawdown()` 메서드, `assess()`에 drawdown 로직 통합 |
| `tests/risk/test_calculator.py` | `TestDrawdownTracking` 8개 테스트 추가 |

## How it works

1. `RiskCalculator`가 `peak_value`를 인스턴스에 추적
2. `assess()` 호출 시 현재 포트폴리오 가치를 peak와 비교
3. `(peak - current) / peak * 100`으로 drawdown % 계산
4. `portfolio.toml`의 `max_drawdown_alert_pct` 초과 시 alert 트리거

## Test plan

- [x] 284 passed (기존 276 + 새 8개)
- [x] ruff clean, pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk