### PR TITLE
refactor: split ConversationEngine into focused modules (closes #65)

### DIFF
--- a/src/tracer/conversation/__init__.py
+++ b/src/tracer/conversation/__init__.py
@@ -1,17 +1,8 @@
-from tracer.conversation.engine import (
-    AnalysisLoop,
-    AnalysisResult,
-    ComparisonSynthesizer,
-    ConversationEngine,
-    EngineResponse,
-    ResponseSynthesizer,
-)
-from tracer.conversation.intent import (
-    INTENT_TOOL_MAP,
-    Intent,
-    IntentParser,
-    IntentType,
-)
+from tracer.conversation.analysis_loop import AnalysisLoop, AnalysisResult
+from tracer.conversation.dispatcher import invoke_tool, invoke_tools
+from tracer.conversation.engine import ConversationEngine, EngineResponse
+from tracer.conversation.intent import INTENT_TOOL_MAP, Intent, IntentParser, IntentType
+from tracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 
 __all__ = [
     "AnalysisLoop",
@@ -24,4 +15,6 @@ __all__ = [
     "IntentParser",
     "IntentType",
     "ResponseSynthesizer",
+    "invoke_tool",
+    "invoke_tools",
 ]

--- a/src/tracer/conversation/analysis_loop.py
+++ b/src/tracer/conversation/analysis_loop.py
@@ -1,0 +1,150 @@
+"""AnalysisLoop — iteratively gathers data until confidence threshold."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+from tracer.conversation.dispatcher import TOOL_DISPATCH, invoke_tools
+from tracer.conversation.intent import Intent
+from tracer.data.registry import DataRegistry
+from tracer.llm.providers import CompletionRequest, CompletionResponse, Message, Role
+from tracer.llm.registry import LLMRegistry
+from tracer.models import ToolResult, TradeThesis
+
+logger = logging.getLogger(__name__)
+
+MAX_ITERATIONS = 3
+CONFIDENCE_THRESHOLD = 0.7
+
+
+@dataclass
+class AnalysisResult:
+    """Output of the AnalysisLoop."""
+
+    results: list[ToolResult] = field(default_factory=list)
+    confidence: float = 0.0
+    iterations: int = 0
+    early_exit_reason: str | None = None
+    trade_thesis: TradeThesis | None = None
+
+
+class AnalysisLoop:
+    """Iteratively gathers data until confidence threshold or max iterations.
+
+    Each iteration:
+    1. Evaluate confidence from collected evidence.
+    2. If confidence >= threshold or iterations exhausted -> exit.
+    3. Otherwise, ask the analyst LLM what data is missing and fetch it.
+    """
+
+    def __init__(
+        self,
+        llm_registry: LLMRegistry,
+        data_registry: DataRegistry,
+        *,
+        max_iterations: int = MAX_ITERATIONS,
+        confidence_threshold: float = CONFIDENCE_THRESHOLD,
+    ) -> None:
+        self._llm = llm_registry
+        self._data = data_registry
+        self._max_iterations = max_iterations
+        self._confidence_threshold = confidence_threshold
+
+    async def run(self, intent: Intent, initial_results: list[ToolResult]) -> AnalysisResult:
+        """Run the analysis loop starting from initial tool results."""
+        all_results = list(initial_results)
+        iterations = 0
+
+        for iteration in range(self._max_iterations):
+            iterations = iteration + 1
+
+            successful = [r for r in all_results if r.success]
+            failed = [r for r in all_results if not r.success]
+
+            if len(failed) >= 2 and iteration == 0:
+                return AnalysisResult(
+                    results=all_results,
+                    confidence=0.0,
+                    iterations=iterations,
+                    early_exit_reason=">=2 tools failed in first iteration",
+                )
+
+            confidence, missing_tools = await self._evaluate(intent, successful)
+
+            if confidence >= self._confidence_threshold:
+                return AnalysisResult(
+                    results=all_results,
+                    confidence=confidence,
+                    iterations=iterations,
+                )
+
+            if not missing_tools or iteration == self._max_iterations - 1:
+                return AnalysisResult(
+                    results=all_results,
+                    confidence=confidence,
+                    iterations=iterations,
+                    early_exit_reason="no additional tools suggested"
+                    if not missing_tools
+                    else None,
+                )
+
+            new_results = await invoke_tools(missing_tools, intent, self._data)
+            all_results.extend(new_results)
+
+        return AnalysisResult(
+            results=all_results,
+            confidence=0.0,
+            iterations=iterations,
+        )
+
+    async def _evaluate(self, intent: Intent, results: list[ToolResult]) -> tuple[float, list[str]]:
+        """Ask the analyst LLM to evaluate confidence and suggest missing tools."""
+        evidence = format_evidence(results)
+        system = (
+            "You are an analyst evaluating whether collected data is sufficient to "
+            "answer a financial query.\n"
+            "Available tools: price_event, news, insider, macro, fundamentals, "
+            "cross_market, memory_search.\n"
+            'Return JSON: {"confidence": 0.0-1.0, "missing_tools": [...]}\n'
+            "confidence = how confident you are the data answers the query.\n"
+            "missing_tools = tools not yet called that would improve the answer "
+            "(empty list if sufficient).\n"
+            "Return ONLY valid JSON."
+        )
+        user_msg = f"Query: {intent.raw_query}\n\nEvidence collected:\n{evidence}"
+
+        try:
+            provider = self._llm.get(Role.ANALYST)
+            response: CompletionResponse = await provider.complete(
+                CompletionRequest(
+                    messages=[
+                        Message(role="system", content=system),
+                        Message(role="user", content=user_msg),
+                    ],
+                    max_tokens=256,
+                    temperature=0.0,
+                )
+            )
+            parsed = json.loads(response.content)
+            confidence = float(parsed.get("confidence", 0.0))
+            missing = [t for t in parsed.get("missing_tools", []) if t in TOOL_DISPATCH]
+            already_called = {r.tool for r in results}
+            missing = [t for t in missing if t not in already_called]
+            return confidence, missing
+        except Exception:
+            logger.warning("AnalysisLoop evaluation failed", exc_info=True)
+            return 0.0, []
+
+
+def format_evidence(results: list[ToolResult]) -> str:
+    """Format tool results into a prompt-friendly string."""
+    if not results:
+        return "(no data collected)"
+    sections: list[str] = []
+    for r in results:
+        sections.append(
+            f"[{r.tool}] source={r.source} stale={r.is_stale}\n{json.dumps(r.data, indent=2)}"
+        )
+    return "\n\n".join(sections)

--- a/src/tracer/conversation/dispatcher.py
+++ b/src/tracer/conversation/dispatcher.py
@@ -1,0 +1,59 @@
+"""Tool dispatcher — routes intent to pipeline tool functions."""
+
+from __future__ import annotations
+
+import asyncio
+
+from tracer.conversation.intent import Intent
+from tracer.data.registry import DataRegistry
+from tracer.models import ToolResult
+from tracer.tools import pipeline
+
+# Maps tool name → the kind of argument it expects.
+TOOL_DISPATCH: dict[str, str] = {
+    "price_event": "ticker",
+    "news": "ticker",
+    "insider": "ticker",
+    "macro": "indicator",
+    "fundamentals": "ticker",
+    "cross_market": "tickers",
+    "memory_search": "query",
+}
+
+
+async def invoke_tool(tool_name: str, intent: Intent, registry: DataRegistry) -> ToolResult:
+    """Invoke a single pipeline tool based on the intent context."""
+    tickers = intent.tickers
+
+    if tool_name == "price_event" and tickers:
+        return await pipeline.price_event(tickers[0], registry)
+    if tool_name == "news" and tickers:
+        return await pipeline.news(tickers[0], registry)
+    if tool_name == "insider" and tickers:
+        return await pipeline.insider(tickers[0], registry)
+    if tool_name == "fundamentals" and tickers:
+        return await pipeline.fundamentals(tickers[0], registry)
+    if tool_name == "cross_market" and tickers:
+        return await pipeline.cross_market(tickers, registry)
+    if tool_name == "macro":
+        return await pipeline.macro(intent.raw_query, registry)
+    if tool_name == "memory_search":
+        return await pipeline.memory_search(intent.raw_query)
+
+    return ToolResult(
+        tool=tool_name,
+        success=False,
+        data={},
+        source="dispatcher",
+        error=f"Cannot invoke {tool_name}: no tickers in query",
+    )
+
+
+async def invoke_tools(
+    tool_names: list[str], intent: Intent, registry: DataRegistry
+) -> list[ToolResult]:
+    """Invoke multiple pipeline tools concurrently."""
+    if not tool_names:
+        return []
+    coros = [invoke_tool(name, intent, registry) for name in tool_names]
+    return list(await asyncio.gather(*coros))

--- a/src/tracer/conversation/engine.py
+++ b/src/tracer/conversation/engine.py
@@ -1,54 +1,34 @@
-"""ConversationEngine — orchestrates the full conversational pipeline.
+"""ConversationEngine — top-level orchestrator for the conversational pipeline.
 
-Wires together IntentParser, pipeline tools, AnalysisLoop, and
-ResponseSynthesizer to process natural-language queries end-to-end.
+Wires together IntentParser, dispatcher, AnalysisLoop, and synthesizers
+to process natural-language queries end-to-end.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 
 from tracer.config.models import PortfolioConfig
+from tracer.conversation.analysis_loop import (
+    CONFIDENCE_THRESHOLD,
+    MAX_ITERATIONS,
+    AnalysisLoop,
+    AnalysisResult,
+)
 from tracer.conversation.context import ConversationContext, extract_context, resolve_pronoun
+from tracer.conversation.dispatcher import invoke_tools
 from tracer.conversation.intent import Intent, IntentParser, IntentType
+from tracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 from tracer.data.registry import DataRegistry, build_registry
-from tracer.llm.providers import CompletionRequest, CompletionResponse, Message, Role
 from tracer.llm.registry import LLMRegistry
 from tracer.memory.session_logger import SessionLogger
 from tracer.models import ToolResult, TradeThesis
 from tracer.tools import pipeline
 
 logger = logging.getLogger(__name__)
-
-# AnalysisLoop defaults
-MAX_ITERATIONS = 3
-CONFIDENCE_THRESHOLD = 0.7
-
-# Dispatcher: maps tool name → callable signature
-_TOOL_DISPATCH: dict[str, str] = {
-    "price_event": "ticker",
-    "news": "ticker",
-    "insider": "ticker",
-    "macro": "indicator",
-    "fundamentals": "ticker",
-    "cross_market": "tickers",
-    "memory_search": "query",
-}
-
-
-@dataclass
-class AnalysisResult:
-    """Output of the AnalysisLoop."""
-
-    results: list[ToolResult] = field(default_factory=list)
-    confidence: float = 0.0
-    iterations: int = 0
-    early_exit_reason: str | None = None
-    trade_thesis: TradeThesis | None = None
 
 
 @dataclass
@@ -61,320 +41,10 @@ class EngineResponse:
     generated_at: datetime = field(default_factory=datetime.now)
 
 
-async def _invoke_tool(tool_name: str, intent: Intent, registry: DataRegistry) -> ToolResult:
-    """Invoke a single pipeline tool based on the intent context."""
-    tickers = intent.tickers
-
-    if tool_name == "price_event" and tickers:
-        return await pipeline.price_event(tickers[0], registry)
-    if tool_name == "news" and tickers:
-        return await pipeline.news(tickers[0], registry)
-    if tool_name == "insider" and tickers:
-        return await pipeline.insider(tickers[0], registry)
-    if tool_name == "fundamentals" and tickers:
-        return await pipeline.fundamentals(tickers[0], registry)
-    if tool_name == "cross_market" and tickers:
-        return await pipeline.cross_market(tickers, registry)
-    if tool_name == "macro":
-        # Use the raw query as the indicator hint for macro lookups.
-        return await pipeline.macro(intent.raw_query, registry)
-    if tool_name == "memory_search":
-        return await pipeline.memory_search(intent.raw_query)
-
-    # Tool requires tickers but none available — return a failed result.
-    return ToolResult(
-        tool=tool_name,
-        success=False,
-        data={},
-        source="dispatcher",
-        error=f"Cannot invoke {tool_name}: no tickers in query",
-    )
-
-
-async def _invoke_tools(
-    tool_names: list[str], intent: Intent, registry: DataRegistry
-) -> list[ToolResult]:
-    """Invoke multiple pipeline tools concurrently."""
-    if not tool_names:
-        return []
-    coros = [_invoke_tool(name, intent, registry) for name in tool_names]
-    return list(await asyncio.gather(*coros))
-
-
-class AnalysisLoop:
-    """Iteratively gathers data until confidence threshold or max iterations.
-
-    Each iteration:
-    1. Evaluate confidence from collected evidence.
-    2. If confidence >= threshold or iterations exhausted → exit.
-    3. Otherwise, ask the analyst LLM what data is missing and fetch it.
-    """
-
-    def __init__(
-        self,
-        llm_registry: LLMRegistry,
-        data_registry: DataRegistry,
-        *,
-        max_iterations: int = MAX_ITERATIONS,
-        confidence_threshold: float = CONFIDENCE_THRESHOLD,
-    ) -> None:
-        self._llm = llm_registry
-        self._data = data_registry
-        self._max_iterations = max_iterations
-        self._confidence_threshold = confidence_threshold
-
-    async def run(self, intent: Intent, initial_results: list[ToolResult]) -> AnalysisResult:
-        """Run the analysis loop starting from initial tool results."""
-        all_results = list(initial_results)
-        iterations = 0
-
-        for iteration in range(self._max_iterations):
-            iterations = iteration + 1
-
-            # Check how many tools failed in this batch.
-            successful = [r for r in all_results if r.success]
-            failed = [r for r in all_results if not r.success]
-
-            if len(failed) >= 2 and iteration == 0:
-                return AnalysisResult(
-                    results=all_results,
-                    confidence=0.0,
-                    iterations=iterations,
-                    early_exit_reason=">=2 tools failed in first iteration",
-                )
-
-            # Ask analyst to evaluate confidence and decide next steps.
-            confidence, missing_tools = await self._evaluate(intent, successful)
-
-            if confidence >= self._confidence_threshold:
-                return AnalysisResult(
-                    results=all_results,
-                    confidence=confidence,
-                    iterations=iterations,
-                )
-
-            if not missing_tools or iteration == self._max_iterations - 1:
-                return AnalysisResult(
-                    results=all_results,
-                    confidence=confidence,
-                    iterations=iterations,
-                    early_exit_reason="no additional tools suggested"
-                    if not missing_tools
-                    else None,
-                )
-
-            # Fetch missing data.
-            new_results = await _invoke_tools(missing_tools, intent, self._data)
-            all_results.extend(new_results)
-
-        return AnalysisResult(
-            results=all_results,
-            confidence=0.0,
-            iterations=iterations,
-        )
-
-    async def _evaluate(self, intent: Intent, results: list[ToolResult]) -> tuple[float, list[str]]:
-        """Ask the analyst LLM to evaluate confidence and suggest missing tools.
-
-        Returns (confidence, list_of_missing_tool_names).
-        """
-        evidence = _format_evidence(results)
-        system = (
-            "You are an analyst evaluating whether collected data is sufficient to "
-            "answer a financial query.\n"
-            "Available tools: price_event, news, insider, macro, fundamentals, "
-            "cross_market, memory_search.\n"
-            'Return JSON: {"confidence": 0.0-1.0, "missing_tools": [...]}\n'
-            "confidence = how confident you are the data answers the query.\n"
-            "missing_tools = tools not yet called that would improve the answer "
-            "(empty list if sufficient).\n"
-            "Return ONLY valid JSON."
-        )
-        user_msg = f"Query: {intent.raw_query}\n\nEvidence collected:\n{evidence}"
-
-        try:
-            provider = self._llm.get(Role.ANALYST)
-            response: CompletionResponse = await provider.complete(
-                CompletionRequest(
-                    messages=[
-                        Message(role="system", content=system),
-                        Message(role="user", content=user_msg),
-                    ],
-                    max_tokens=256,
-                    temperature=0.0,
-                )
-            )
-            parsed = json.loads(response.content)
-            confidence = float(parsed.get("confidence", 0.0))
-            missing = [t for t in parsed.get("missing_tools", []) if t in _TOOL_DISPATCH]
-            # Don't re-call tools we already have results for.
-            already_called = {r.tool for r in results}
-            missing = [t for t in missing if t not in already_called]
-            return confidence, missing
-        except Exception:
-            logger.warning("AnalysisLoop evaluation failed", exc_info=True)
-            return 0.0, []
-
-
-class ResponseSynthesizer:
-    """Synthesizes a final response from analysis results.
-
-    Produces the spec response format: causal chain, adversarial check,
-    conviction score.
-    """
-
-    def __init__(self, llm_registry: LLMRegistry) -> None:
-        self._llm = llm_registry
-
-    async def synthesize(self, intent: Intent, analysis: AnalysisResult) -> str:
-        """Generate the final user-facing response."""
-        evidence = _format_evidence([r for r in analysis.results if r.success])
-        failed_tools = [r.tool for r in analysis.results if not r.success]
-
-        ticker_str = ", ".join(intent.tickers) if intent.tickers else "general market"
-        today = datetime.now().strftime("%Y-%m-%d")
-
-        system = (
-            "You are a senior financial analyst. Synthesize the evidence into a "
-            "structured response.\n\n"
-            "Use this EXACT format:\n"
-            f"[ANALYSIS: {ticker_str} — {today}]\n"
-            "Conviction: {{score}}/10\n\n"
-            "WHAT HAPPENED\n"
-            "{{1-2 sentence direct answer}}\n\n"
-            "EVIDENCE CHAIN\n"
-            "{{numbered evidence items with source and conclusion}}\n\n"
-            "ADVERSARIAL CHECK\n"
-            "{{bullet points: reasons this could be wrong, data caveats}}\n\n"
-            "VERDICT\n"
-            "{{final judgment with conviction score and key qualifier}}"
-        )
-
-        caveats = ""
-        if failed_tools:
-            caveats = (
-                f"\n\nNote: the following data sources were unavailable: "
-                f"{', '.join(failed_tools)}. Flag this in ADVERSARIAL CHECK."
-            )
-
-        if analysis.early_exit_reason:
-            caveats += (
-                f"\nAnalysis exited early: {analysis.early_exit_reason}. "
-                "Acknowledge data limitations."
-            )
-
-        user_msg = (
-            f"Query: {intent.raw_query}\n\n"
-            f"Evidence (confidence={analysis.confidence:.2f}, "
-            f"iterations={analysis.iterations}):\n{evidence}{caveats}"
-        )
-
-        try:
-            provider = self._llm.get(Role.STRATEGIST)
-            response = await provider.complete(
-                CompletionRequest(
-                    messages=[
-                        Message(role="system", content=system),
-                        Message(role="user", content=user_msg),
-                    ],
-                    max_tokens=2048,
-                    temperature=0.2,
-                )
-            )
-            return response.content
-        except Exception:
-            logger.warning("ResponseSynthesizer failed, returning raw evidence", exc_info=True)
-            return self._fallback_response(intent, analysis)
-
-    def _fallback_response(self, intent: Intent, analysis: AnalysisResult) -> str:
-        """Minimal plain-text fallback when the LLM is unavailable."""
-        lines = [f"[ANALYSIS: {', '.join(intent.tickers) or 'general'}]"]
-        lines.append(f"Query: {intent.raw_query}")
-        lines.append(f"Confidence: {analysis.confidence:.2f}")
-        lines.append("")
-        for r in analysis.results:
-            status = "OK" if r.success else f"FAILED ({r.error})"
-            lines.append(f"  [{r.tool}] {status}")
-        lines.append("")
-        lines.append("(Full synthesis unavailable — LLM error)")
-        return "\n".join(lines)
-
-
-class ComparisonSynthesizer:
-    """Synthesizes a side-by-side comparison for multiple tickers."""
-
-    def __init__(self, llm_registry: LLMRegistry) -> None:
-        self._llm = llm_registry
-
-    async def synthesize(
-        self, intent: Intent, per_ticker_results: dict[str, list[ToolResult]]
-    ) -> str:
-        """Generate a comparative response table with verdict."""
-        evidence_sections: list[str] = []
-        for ticker, results in per_ticker_results.items():
-            successful = [r for r in results if r.success]
-            evidence_sections.append(f"--- {ticker} ---\n{_format_evidence(successful)}")
-        combined_evidence = "\n\n".join(evidence_sections)
-        tickers_str = ", ".join(intent.tickers)
-        today = datetime.now().strftime("%Y-%m-%d")
-
-        header = "| Metric | " + " | ".join(intent.tickers) + " |"
-        separator = "|" + "---|" * (len(intent.tickers) + 1)
-
-        system = (
-            "You are a senior financial analyst. Compare the given tickers "
-            "side-by-side.\n\n"
-            "Use this EXACT format:\n"
-            f"[COMPARISON: {tickers_str} — {today}]\n\n"
-            f"{header}\n{separator}\n"
-            "| Price | ... |\n"
-            "| PE Ratio | ... |\n"
-            "| Revenue Growth | ... |\n"
-            "| Conviction | ... |\n"
-            "(add more rows as the data supports)\n\n"
-            "VERDICT\n"
-            "{{comparative analysis: which ticker is stronger and why, "
-            "1-3 sentences}}"
-        )
-        user_msg = f"Query: {intent.raw_query}\n\nEvidence per ticker:\n{combined_evidence}"
-
-        try:
-            provider = self._llm.get(Role.STRATEGIST)
-            response = await provider.complete(
-                CompletionRequest(
-                    messages=[
-                        Message(role="system", content=system),
-                        Message(role="user", content=user_msg),
-                    ],
-                    max_tokens=2048,
-                    temperature=0.2,
-                )
-            )
-            return response.content
-        except Exception:
-            logger.warning("ComparisonSynthesizer failed, returning fallback", exc_info=True)
-            return self._fallback_response(intent, per_ticker_results)
-
-    def _fallback_response(
-        self, intent: Intent, per_ticker_results: dict[str, list[ToolResult]]
-    ) -> str:
-        lines = [f"[COMPARISON: {', '.join(intent.tickers)}]"]
-        lines.append(f"Query: {intent.raw_query}")
-        lines.append("")
-        for ticker, results in per_ticker_results.items():
-            lines.append(f"  {ticker}:")
-            for r in results:
-                status = "OK" if r.success else f"FAILED ({r.error})"
-                lines.append(f"    [{r.tool}] {status}")
-        lines.append("")
-        lines.append("(Full comparison unavailable — LLM error)")
-        return "\n".join(lines)
-
-
 class ConversationEngine:
     """Top-level orchestrator that wires together the conversational pipeline.
 
-    Flow: IntentParser → pipeline tools → AnalysisLoop → ResponseSynthesizer
+    Flow: IntentParser -> dispatcher -> AnalysisLoop -> Synthesizer
     """
 
     def __init__(
@@ -442,29 +112,38 @@ class ConversationEngine:
 
         # 2. Comparison branch: per-ticker analysis + comparison table.
         if intent.intent_type == IntentType.COMPARISON and len(intent.tickers) >= 2:
-            single_intents = [
-                Intent(
-                    intent_type=IntentType.COMPARISON,
-                    tickers=[ticker],
-                    tools=intent.tools,
-                    raw_query=intent.raw_query,
-                )
-                for ticker in intent.tickers
-            ]
-            gathered = await asyncio.gather(
-                *[_invoke_tools(si.tools, si, self._data) for si in single_intents]
+            return await self._handle_comparison(intent)
+
+        # 3. Standard analysis path.
+        return await self._handle_standard(intent)
+
+    async def _handle_comparison(self, intent: Intent) -> EngineResponse:
+        """Run per-ticker analysis concurrently and synthesize comparison."""
+        single_intents = [
+            Intent(
+                intent_type=IntentType.COMPARISON,
+                tickers=[ticker],
+                tools=intent.tools,
+                raw_query=intent.raw_query,
             )
-            per_ticker_results: dict[str, list[ToolResult]] = dict(zip(intent.tickers, gathered))
-            all_results = [r for results in per_ticker_results.values() for r in results]
-            analysis = AnalysisResult(results=all_results, confidence=0.7, iterations=1)
-            text = await self._comparison_synthesizer.synthesize(intent, per_ticker_results)
-            self._history.append({"role": "assistant", "content": text})
-            return EngineResponse(text=text, intent=intent, analysis=analysis)
+            for ticker in intent.tickers
+        ]
+        gathered = await asyncio.gather(
+            *[invoke_tools(si.tools, si, self._data) for si in single_intents]
+        )
+        per_ticker_results: dict[str, list[ToolResult]] = dict(zip(intent.tickers, gathered))
+        all_results = [r for results in per_ticker_results.values() for r in results]
+        analysis = AnalysisResult(results=all_results, confidence=0.7, iterations=1)
+        text = await self._comparison_synthesizer.synthesize(intent, per_ticker_results)
+        self._history.append({"role": "assistant", "content": text})
+        return EngineResponse(text=text, intent=intent, analysis=analysis)
 
-        # 3. Invoke initial pipeline tools (standard path).
-        initial_results = await _invoke_tools(intent.tools, intent, self._data)
+    async def _handle_standard(self, intent: Intent) -> EngineResponse:
+        """Run the standard analysis pipeline (DeepPath)."""
+        # Invoke initial pipeline tools.
+        initial_results = await invoke_tools(intent.tools, intent, self._data)
 
-        # 4. Run analysis loop.
+        # Run analysis loop.
         analysis = await self._analysis_loop.run(intent, initial_results)
         logger.info(
             "Analysis complete: confidence=%.2f iterations=%d",
@@ -472,7 +151,7 @@ class ConversationEngine:
             analysis.iterations,
         )
 
-        # 4. Trade thesis generation (step 7) — only when tickers are present.
+        # Trade thesis generation (step 7) — only when tickers are present.
         if intent.tickers:
             thesis_result = await pipeline.trade_thesis(
                 intent.tickers[0], analysis.results, self._llm
@@ -495,7 +174,7 @@ class ConversationEngine:
                 except (KeyError, ValueError, TypeError):
                     logger.warning("Failed to reconstruct TradeThesis from result")
 
-        # 5. Risk check (step 8) — only when a trade thesis was produced.
+        # Risk check (step 8) — only when a trade thesis was produced.
         if analysis.trade_thesis is not None and self._portfolio_config.holdings:
             risk_result = await pipeline.risk_check(
                 analysis.trade_thesis.ticker,
@@ -505,25 +184,8 @@ class ConversationEngine:
             )
             analysis.results.append(risk_result)
 
-        # 6. Synthesize response.
+        # Synthesize response.
         text = await self._synthesizer.synthesize(intent, analysis)
-
         self._history.append({"role": "assistant", "content": text})
 
-        return EngineResponse(
-            text=text,
-            intent=intent,
-            analysis=analysis,
-        )
-
-
-def _format_evidence(results: list[ToolResult]) -> str:
-    """Format tool results into a prompt-friendly string."""
-    if not results:
-        return "(no data collected)"
-    sections: list[str] = []
-    for r in results:
-        sections.append(
-            f"[{r.tool}] source={r.source} stale={r.is_stale}\n{json.dumps(r.data, indent=2)}"
-        )
-    return "\n\n".join(sections)
+        return EngineResponse(text=text, intent=intent, analysis=analysis)

--- a/src/tracer/conversation/synthesizer.py
+++ b/src/tracer/conversation/synthesizer.py
@@ -1,0 +1,169 @@
+"""Response synthesizers — format analysis results for the user."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from tracer.conversation.analysis_loop import AnalysisResult, format_evidence
+from tracer.conversation.intent import Intent
+from tracer.llm.providers import CompletionRequest, Message, Role
+from tracer.llm.registry import LLMRegistry
+from tracer.models import ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+class ResponseSynthesizer:
+    """Synthesizes a final response from analysis results.
+
+    Produces the spec response format: causal chain, adversarial check,
+    conviction score.
+    """
+
+    def __init__(self, llm_registry: LLMRegistry) -> None:
+        self._llm = llm_registry
+
+    async def synthesize(self, intent: Intent, analysis: AnalysisResult) -> str:
+        """Generate the final user-facing response."""
+        evidence = format_evidence([r for r in analysis.results if r.success])
+        failed_tools = [r.tool for r in analysis.results if not r.success]
+
+        ticker_str = ", ".join(intent.tickers) if intent.tickers else "general market"
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        system = (
+            "You are a senior financial analyst. Synthesize the evidence into a "
+            "structured response.\n\n"
+            "Use this EXACT format:\n"
+            f"[ANALYSIS: {ticker_str} — {today}]\n"
+            "Conviction: {{score}}/10\n\n"
+            "WHAT HAPPENED\n"
+            "{{1-2 sentence direct answer}}\n\n"
+            "EVIDENCE CHAIN\n"
+            "{{numbered evidence items with source and conclusion}}\n\n"
+            "ADVERSARIAL CHECK\n"
+            "{{bullet points: reasons this could be wrong, data caveats}}\n\n"
+            "VERDICT\n"
+            "{{final judgment with conviction score and key qualifier}}"
+        )
+
+        caveats = ""
+        if failed_tools:
+            caveats = (
+                f"\n\nNote: the following data sources were unavailable: "
+                f"{', '.join(failed_tools)}. Flag this in ADVERSARIAL CHECK."
+            )
+
+        if analysis.early_exit_reason:
+            caveats += (
+                f"\nAnalysis exited early: {analysis.early_exit_reason}. "
+                "Acknowledge data limitations."
+            )
+
+        user_msg = (
+            f"Query: {intent.raw_query}\n\n"
+            f"Evidence (confidence={analysis.confidence:.2f}, "
+            f"iterations={analysis.iterations}):\n{evidence}{caveats}"
+        )
+
+        try:
+            provider = self._llm.get(Role.STRATEGIST)
+            response = await provider.complete(
+                CompletionRequest(
+                    messages=[
+                        Message(role="system", content=system),
+                        Message(role="user", content=user_msg),
+                    ],
+                    max_tokens=2048,
+                    temperature=0.2,
+                )
+            )
+            return response.content
+        except Exception:
+            logger.warning("ResponseSynthesizer failed, returning raw evidence", exc_info=True)
+            return self._fallback_response(intent, analysis)
+
+    def _fallback_response(self, intent: Intent, analysis: AnalysisResult) -> str:
+        """Minimal plain-text fallback when the LLM is unavailable."""
+        lines = [f"[ANALYSIS: {', '.join(intent.tickers) or 'general'}]"]
+        lines.append(f"Query: {intent.raw_query}")
+        lines.append(f"Confidence: {analysis.confidence:.2f}")
+        lines.append("")
+        for r in analysis.results:
+            status = "OK" if r.success else f"FAILED ({r.error})"
+            lines.append(f"  [{r.tool}] {status}")
+        lines.append("")
+        lines.append("(Full synthesis unavailable — LLM error)")
+        return "\n".join(lines)
+
+
+class ComparisonSynthesizer:
+    """Synthesizes a side-by-side comparison for multiple tickers."""
+
+    def __init__(self, llm_registry: LLMRegistry) -> None:
+        self._llm = llm_registry
+
+    async def synthesize(
+        self, intent: Intent, per_ticker_results: dict[str, list[ToolResult]]
+    ) -> str:
+        """Generate a comparative response table with verdict."""
+        evidence_sections: list[str] = []
+        for ticker, results in per_ticker_results.items():
+            successful = [r for r in results if r.success]
+            evidence_sections.append(f"--- {ticker} ---\n{format_evidence(successful)}")
+        combined_evidence = "\n\n".join(evidence_sections)
+        tickers_str = ", ".join(intent.tickers)
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        header = "| Metric | " + " | ".join(intent.tickers) + " |"
+        separator = "|" + "---|" * (len(intent.tickers) + 1)
+
+        system = (
+            "You are a senior financial analyst. Compare the given tickers "
+            "side-by-side.\n\n"
+            "Use this EXACT format:\n"
+            f"[COMPARISON: {tickers_str} — {today}]\n\n"
+            f"{header}\n{separator}\n"
+            "| Price | ... |\n"
+            "| PE Ratio | ... |\n"
+            "| Revenue Growth | ... |\n"
+            "| Conviction | ... |\n"
+            "(add more rows as the data supports)\n\n"
+            "VERDICT\n"
+            "{{comparative analysis: which ticker is stronger and why, "
+            "1-3 sentences}}"
+        )
+        user_msg = f"Query: {intent.raw_query}\n\nEvidence per ticker:\n{combined_evidence}"
+
+        try:
+            provider = self._llm.get(Role.STRATEGIST)
+            response = await provider.complete(
+                CompletionRequest(
+                    messages=[
+                        Message(role="system", content=system),
+                        Message(role="user", content=user_msg),
+                    ],
+                    max_tokens=2048,
+                    temperature=0.2,
+                )
+            )
+            return response.content
+        except Exception:
+            logger.warning("ComparisonSynthesizer failed, returning fallback", exc_info=True)
+            return self._fallback_response(intent, per_ticker_results)
+
+    def _fallback_response(
+        self, intent: Intent, per_ticker_results: dict[str, list[ToolResult]]
+    ) -> str:
+        lines = [f"[COMPARISON: {', '.join(intent.tickers)}]"]
+        lines.append(f"Query: {intent.raw_query}")
+        lines.append("")
+        for ticker, results in per_ticker_results.items():
+            lines.append(f"  {ticker}:")
+            for r in results:
+                status = "OK" if r.success else f"FAILED ({r.error})"
+                lines.append(f"    [{r.tool}] {status}")
+        lines.append("")
+        lines.append("(Full comparison unavailable — LLM error)")
+        return "\n".join(lines)

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -10,23 +10,17 @@ from helpers import make_mock_llm_registry as _mock_llm_registry
 from helpers import ok_result as _ok_result
 
 from tracer.config.models import Holding, PortfolioConfig
-from tracer.conversation.engine import (
-    AnalysisLoop,
-    AnalysisResult,
-    ComparisonSynthesizer,
-    ConversationEngine,
-    EngineResponse,
-    ResponseSynthesizer,
-    _invoke_tool,
-    _invoke_tools,
-)
+from tracer.conversation.analysis_loop import AnalysisLoop, AnalysisResult
+from tracer.conversation.dispatcher import invoke_tool, invoke_tools
+from tracer.conversation.engine import ConversationEngine, EngineResponse
 from tracer.conversation.intent import Intent, IntentType
+from tracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 from tracer.data.registry import DataRegistry
 from tracer.llm.providers import Role
 from tracer.llm.registry import LLMRegistry
 
 # ---------------------------------------------------------------------------
-# _invoke_tool / _invoke_tools
+# invoke_tool / invoke_tools
 # ---------------------------------------------------------------------------
 
 
@@ -34,64 +28,64 @@ class TestInvokeTool:
     async def test_price_event_with_ticker(self) -> None:
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
         registry = DataRegistry()
-        with patch("tracer.conversation.engine.pipeline") as mock_pipeline:
+        with patch("tracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.price_event = AsyncMock(return_value=_ok_result("price_event"))
-            result = await _invoke_tool("price_event", intent, registry)
+            result = await invoke_tool("price_event", intent, registry)
             assert result.success
             mock_pipeline.price_event.assert_called_once_with("AAPL", registry)
 
     async def test_news_with_ticker(self) -> None:
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["TSLA"], raw_query="test")
         registry = DataRegistry()
-        with patch("tracer.conversation.engine.pipeline") as mock_pipeline:
+        with patch("tracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.news = AsyncMock(return_value=_ok_result("news"))
-            result = await _invoke_tool("news", intent, registry)
+            result = await invoke_tool("news", intent, registry)
             assert result.success
 
     async def test_cross_market_passes_all_tickers(self) -> None:
         intent = Intent(IntentType.CROSS_MARKET, tickers=["AAPL", "TSLA"], raw_query="test")
         registry = DataRegistry()
-        with patch("tracer.conversation.engine.pipeline") as mock_pipeline:
+        with patch("tracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.cross_market = AsyncMock(return_value=_ok_result("cross_market"))
-            await _invoke_tool("cross_market", intent, registry)
+            await invoke_tool("cross_market", intent, registry)
             mock_pipeline.cross_market.assert_called_once_with(["AAPL", "TSLA"], registry)
 
     async def test_macro_uses_raw_query(self) -> None:
         intent = Intent(IntentType.MACRO_QUERY, raw_query="inflation rate")
         registry = DataRegistry()
-        with patch("tracer.conversation.engine.pipeline") as mock_pipeline:
+        with patch("tracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.macro = AsyncMock(return_value=_ok_result("macro"))
-            await _invoke_tool("macro", intent, registry)
+            await invoke_tool("macro", intent, registry)
             mock_pipeline.macro.assert_called_once_with("inflation rate", registry)
 
     async def test_memory_search(self) -> None:
         intent = Intent(IntentType.FOLLOW_UP, raw_query="what about before?")
         registry = DataRegistry()
-        with patch("tracer.conversation.engine.pipeline") as mock_pipeline:
+        with patch("tracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.memory_search = AsyncMock(return_value=_ok_result("memory_search"))
-            await _invoke_tool("memory_search", intent, registry)
+            await invoke_tool("memory_search", intent, registry)
             mock_pipeline.memory_search.assert_called_once_with("what about before?")
 
     async def test_tool_without_tickers_returns_failure(self) -> None:
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=[], raw_query="test")
         registry = DataRegistry()
-        result = await _invoke_tool("price_event", intent, registry)
+        result = await invoke_tool("price_event", intent, registry)
         assert not result.success
         assert result.error is not None and "no tickers" in result.error
 
     async def test_invoke_tools_concurrent(self) -> None:
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
         registry = DataRegistry()
-        with patch("tracer.conversation.engine.pipeline") as mock_pipeline:
+        with patch("tracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.price_event = AsyncMock(return_value=_ok_result("price_event"))
             mock_pipeline.news = AsyncMock(return_value=_ok_result("news"))
-            results = await _invoke_tools(["price_event", "news"], intent, registry)
+            results = await invoke_tools(["price_event", "news"], intent, registry)
             assert len(results) == 2
             assert all(r.success for r in results)
 
     async def test_invoke_tools_empty_list(self) -> None:
         intent = Intent(IntentType.FOLLOW_UP, raw_query="ok")
-        results = await _invoke_tools([], intent, DataRegistry())
+        results = await invoke_tools([], intent, DataRegistry())
         assert results == []
 
 
@@ -127,7 +121,7 @@ class TestAnalysisLoop:
         loop = AnalysisLoop(llm, data)
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
 
-        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
             mock_invoke.return_value = [_ok_result("news")]
             result = await loop.run(intent, [_ok_result("price_event")])
 
@@ -144,7 +138,7 @@ class TestAnalysisLoop:
         loop = AnalysisLoop(llm, data, max_iterations=2)
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=["AAPL"], raw_query="test")
 
-        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
             mock_invoke.return_value = [_ok_result("news")]
             result = await loop.run(intent, [_ok_result("price_event")])
 
@@ -271,7 +265,7 @@ class TestConversationEngine:
 
         engine = ConversationEngine(llm, data)
 
-        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
             mock_invoke.return_value = [_ok_result("price_event"), _ok_result("news")]
             response = await engine.query("Why did AAPL spike 5% today?")
 
@@ -296,7 +290,7 @@ class TestConversationEngine:
 
         engine = ConversationEngine(llm, DataRegistry())
 
-        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
             mock_invoke.return_value = [_ok_result("macro")]
             await engine.query("Where are we in the rate cycle?")
 
@@ -335,7 +329,7 @@ class TestConversationEngine:
         engine = ConversationEngine(llm, DataRegistry(), portfolio_config=portfolio)
 
         with (
-            patch("tracer.conversation.engine._invoke_tools") as mock_invoke,
+            patch("tracer.conversation.engine.invoke_tools") as mock_invoke,
             patch("tracer.conversation.engine.pipeline.risk_check") as mock_risk,
         ):
             mock_invoke.return_value = [_ok_result("price_event")]
@@ -383,7 +377,7 @@ class TestConversationEngine:
         engine = ConversationEngine(llm, DataRegistry())
 
         with (
-            patch("tracer.conversation.engine._invoke_tools") as mock_invoke,
+            patch("tracer.conversation.engine.invoke_tools") as mock_invoke,
             patch("tracer.conversation.engine.pipeline.risk_check") as mock_risk,
         ):
             mock_invoke.return_value = [_ok_result("price_event")]
@@ -412,7 +406,7 @@ class TestConversationEngine:
         engine = ConversationEngine(llm, DataRegistry(), portfolio_config=portfolio)
 
         with (
-            patch("tracer.conversation.engine._invoke_tools") as mock_invoke,
+            patch("tracer.conversation.engine.invoke_tools") as mock_invoke,
             patch("tracer.conversation.engine.pipeline.risk_check") as mock_risk,
         ):
             mock_invoke.return_value = [_ok_result("price_event")]
@@ -435,7 +429,7 @@ class TestConversationEngine:
             confidence_threshold=0.9,
         )
 
-        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
             mock_invoke.return_value = []
             response = await engine.query("test")
 
@@ -514,7 +508,7 @@ class TestConversationEngineComparison:
         llm = _mock_llm_registry({Role.RESEARCHER: intent_resp, Role.STRATEGIST: comparison_resp})
         engine = ConversationEngine(llm, DataRegistry())
 
-        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
             mock_invoke.return_value = [_ok_result("price_event"), _ok_result("fundamentals")]
             response = await engine.query("Compare AAPL and MSFT")
 
@@ -537,7 +531,7 @@ class TestConversationEngineComparison:
         )
         engine = ConversationEngine(llm, DataRegistry())
 
-        with patch("tracer.conversation.engine._invoke_tools") as mock_invoke:
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
             mock_invoke.return_value = [_ok_result("price_event")]
             response = await engine.query("Compare AAPL")
 


### PR DESCRIPTION
## Summary

`conversation/engine.py` (530줄)을 단일 책임 원칙에 따라 4개 모듈로 분리합니다 (closes #65).

## Before → After

| Before | After | Lines | 역할 |
|--------|-------|-------|------|
| engine.py (530줄) | engine.py | 191 | ConversationEngine 오케스트레이터 |
| | analysis_loop.py | 150 | AnalysisLoop, AnalysisResult, format_evidence |
| | synthesizer.py | 169 | ResponseSynthesizer, ComparisonSynthesizer |
| | dispatcher.py | 59 | invoke_tool, invoke_tools |

## Test plan

- [x] 284 passed (기존 전부 통과, import 경로 업데이트)
- [x] ruff check/format clean
- [x] pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk