### PR TITLE
feat: wire SessionLogger/SessionCompactor into ConversationEngine (closes #64)

### DIFF
--- a/src/tracer/cli.py
+++ b/src/tracer/cli.py
@@ -277,10 +277,20 @@ def repl() -> None:
         stream=sys.stderr,
     )
 
+    import uuid
+
     from tracer.conversation.engine import ConversationEngine
+    from tracer.memory.session_logger import SessionLogger
 
     llm_registry, data_registry = _build_registries()
-    engine = ConversationEngine(llm_registry, data_registry)
+
+    # Create session logger in ~/.qracer/sessions/<uuid>.jsonl
+    sessions_dir = _user_dir() / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    session_id = uuid.uuid4().hex[:12]
+    session_logger = SessionLogger(sessions_dir / f"{session_id}.jsonl")
+
+    engine = ConversationEngine(llm_registry, data_registry, session_logger=session_logger)
     asyncio.run(_repl_loop(engine))
 
 

--- a/src/tracer/conversation/engine.py
+++ b/src/tracer/conversation/engine.py
@@ -24,7 +24,8 @@ from tracer.conversation.intent import Intent, IntentParser, IntentType
 from tracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 from tracer.data.registry import DataRegistry, build_registry
 from tracer.llm.registry import LLMRegistry
-from tracer.memory.session_logger import SessionLogger
+from tracer.memory.session_compactor import SessionCompactor
+from tracer.memory.session_logger import SessionLogger, TurnRecord
 from tracer.models import ToolResult, TradeThesis
 from tracer.tools import pipeline
 
@@ -73,16 +74,43 @@ class ConversationEngine:
         self._portfolio_config = portfolio_config or PortfolioConfig()
         self._history: list[dict] = []
         self._session_logger = session_logger
+        self._compactor = SessionCompactor(llm_registry) if session_logger else None
         self._context: ConversationContext = ConversationContext()
+        self._turn_counter = 0
 
     @property
     def history(self) -> list[dict]:
         """Turn history for the current session."""
         return list(self._history)
 
+    def _log_turn(self, role: str, content: str, **kwargs: object) -> None:
+        """Append a turn to the session log if a logger is configured."""
+        if self._session_logger is None:
+            return
+        self._turn_counter += 1
+        self._session_logger.append(
+            TurnRecord(turn=self._turn_counter, role=role, content=content, **kwargs)  # type: ignore[arg-type]
+        )
+
+    async def _maybe_compact(self) -> None:
+        """Trigger compaction if the session log exceeds the token threshold."""
+        if self._compactor is None or self._session_logger is None:
+            return
+        if self._compactor.needs_compaction(self._session_logger):
+            try:
+                result = await self._compactor.compact(self._session_logger)
+                logger.info(
+                    "Session compacted: %d turns → %d tokens summary",
+                    result.turn_count,
+                    result.output_tokens,
+                )
+            except Exception:
+                logger.warning("Session compaction failed", exc_info=True)
+
     async def query(self, user_input: str) -> EngineResponse:
         """Process a user query through the full pipeline."""
         self._history.append({"role": "user", "content": user_input})
+        self._log_turn("user", user_input)
 
         # 0. Extract conversation context from session log.
         if self._session_logger is not None:
@@ -136,6 +164,8 @@ class ConversationEngine:
         analysis = AnalysisResult(results=all_results, confidence=0.7, iterations=1)
         text = await self._comparison_synthesizer.synthesize(intent, per_ticker_results)
         self._history.append({"role": "assistant", "content": text})
+        self._log_turn("assistant", text)
+        await self._maybe_compact()
         return EngineResponse(text=text, intent=intent, analysis=analysis)
 
     async def _handle_standard(self, intent: Intent) -> EngineResponse:
@@ -187,5 +217,7 @@ class ConversationEngine:
         # Synthesize response.
         text = await self._synthesizer.synthesize(intent, analysis)
         self._history.append({"role": "assistant", "content": text})
+        self._log_turn("assistant", text)
+        await self._maybe_compact()
 
         return EngineResponse(text=text, intent=intent, analysis=analysis)

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -537,3 +537,87 @@ class TestConversationEngineComparison:
 
         assert response.intent.intent_type == IntentType.COMPARISON
         assert "ANALYSIS" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Session logging integration
+# ---------------------------------------------------------------------------
+
+
+class TestSessionLogging:
+    async def test_query_logs_user_and_assistant_turns(self, tmp_path) -> None:
+        """Engine should log user input and assistant response to SessionLogger."""
+        from tracer.memory.session_logger import SessionLogger
+
+        log_path = tmp_path / "test.jsonl"
+        session_logger = SessionLogger(log_path)
+
+        intent_resp = json.dumps({"intent": "macro_query", "tickers": []})
+        analysis_resp = json.dumps({"confidence": 0.85, "missing_tools": []})
+
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: intent_resp,
+                Role.ANALYST: analysis_resp,
+                Role.STRATEGIST: "Response text",
+            }
+        )
+        engine = ConversationEngine(llm, DataRegistry(), session_logger=session_logger)
+
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
+            mock_invoke.return_value = []
+            await engine.query("What is inflation?")
+
+        turns = session_logger.read_all()
+        assert len(turns) >= 2
+        assert turns[0].role == "user"
+        assert turns[0].content == "What is inflation?"
+        assert turns[-1].role == "assistant"
+
+    async def test_turn_counter_increments(self, tmp_path) -> None:
+        """Turn counter should increment across multiple queries."""
+        from tracer.memory.session_logger import SessionLogger
+
+        log_path = tmp_path / "test.jsonl"
+        session_logger = SessionLogger(log_path)
+
+        intent_resp = json.dumps({"intent": "macro_query", "tickers": []})
+        analysis_resp = json.dumps({"confidence": 0.85, "missing_tools": []})
+
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: [intent_resp, intent_resp],
+                Role.ANALYST: [analysis_resp, analysis_resp],
+                Role.STRATEGIST: ["Response 1", "Response 2"],
+            }
+        )
+        engine = ConversationEngine(llm, DataRegistry(), session_logger=session_logger)
+
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
+            mock_invoke.return_value = []
+            await engine.query("Query 1")
+            await engine.query("Query 2")
+
+        turns = session_logger.read_all()
+        turn_numbers = [t.turn for t in turns]
+        assert turn_numbers == [1, 2, 3, 4]  # user1, assistant1, user2, assistant2
+
+    async def test_no_logging_without_session_logger(self) -> None:
+        """Engine without session_logger should work normally without errors."""
+        intent_resp = json.dumps({"intent": "macro_query", "tickers": []})
+        analysis_resp = json.dumps({"confidence": 0.85, "missing_tools": []})
+
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: intent_resp,
+                Role.ANALYST: analysis_resp,
+                Role.STRATEGIST: "Response",
+            }
+        )
+        engine = ConversationEngine(llm, DataRegistry())  # no session_logger
+
+        with patch("tracer.conversation.engine.invoke_tools") as mock_invoke:
+            mock_invoke.return_value = []
+            response = await engine.query("Test query")
+
+        assert response.text == "Response"


### PR DESCRIPTION
## Summary

기존에 개별 모듈로만 존재하던 SessionLogger와 SessionCompactor를 ConversationEngine에 실제로 연결합니다 (closes #64).

## Changes

| 파일 | 변경 |
|------|------|
| `src/tracer/conversation/engine.py` | `_log_turn()` 헬퍼, `_maybe_compact()` 자동 압축, `query()`에서 user/assistant 턴 로깅 |
| `src/tracer/cli.py` | `repl()`에서 `SessionLogger` 생성 (`~/.qracer/sessions/<uuid>.jsonl`) 후 엔진에 주입 |
| `tests/conversation/test_engine.py` | 3개 테스트 추가 (턴 로깅, 카운터 증가, logger 없이 정상 동작) |

## How it works

1. `repl()` 시작 시 `~/.qracer/sessions/<session_id>.jsonl` 파일 생성
2. 매 `query()` 호출마다 user input → assistant response를 `TurnRecord`로 기록
3. 기록 후 토큰 추정치가 8,000을 초과하면 `SessionCompactor.compact()` 자동 트리거
4. `session_logger`가 None이면 기존과 동일하게 동작 (no-op)

## Test plan

- [x] 287 passed (기존 284 + 새 3개)
- [x] ruff clean, pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk