### PR TITLE
feat: analysis report export to Markdown/JSON (closes #47)

### DIFF
--- a/src/tracer/cli.py
+++ b/src/tracer/cli.py
@@ -258,6 +258,22 @@ async def _repl_loop(engine: object) -> None:
             click.echo("Goodbye.")
             break
 
+        if user_input.lower() in ("save", "save analysis", "/save"):
+            path = engine.save_last_report()  # type: ignore[attr-defined]
+            if path:
+                click.echo(f"Saved to {path}\n")
+            else:
+                click.echo("No analysis to save.\n")
+            continue
+
+        if user_input.lower() in ("save json", "/save json"):
+            path = engine.save_last_report(fmt="json")  # type: ignore[attr-defined]
+            if path:
+                click.echo(f"Saved to {path}\n")
+            else:
+                click.echo("No analysis to save.\n")
+            continue
+
         try:
             response = await engine.query(user_input)  # type: ignore[attr-defined]
             click.echo()
@@ -290,7 +306,14 @@ def repl() -> None:
     session_id = uuid.uuid4().hex[:12]
     session_logger = SessionLogger(sessions_dir / f"{session_id}.jsonl")
 
-    engine = ConversationEngine(llm_registry, data_registry, session_logger=session_logger)
+    reports_dir = _user_dir() / "reports"
+
+    engine = ConversationEngine(
+        llm_registry,
+        data_registry,
+        session_logger=session_logger,
+        report_dir=reports_dir,
+    )
     asyncio.run(_repl_loop(engine))
 
 

--- a/src/tracer/conversation/__init__.py
+++ b/src/tracer/conversation/__init__.py
@@ -2,6 +2,7 @@ from tracer.conversation.analysis_loop import AnalysisLoop, AnalysisResult
 from tracer.conversation.dispatcher import invoke_tool, invoke_tools
 from tracer.conversation.engine import ConversationEngine, EngineResponse
 from tracer.conversation.intent import INTENT_TOOL_MAP, Intent, IntentParser, IntentType
+from tracer.conversation.report_exporter import ReportExporter
 from tracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "Intent",
     "IntentParser",
     "IntentType",
+    "ReportExporter",
     "ResponseSynthesizer",
     "invoke_tool",
     "invoke_tools",

--- a/src/tracer/conversation/engine.py
+++ b/src/tracer/conversation/engine.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 
 from tracer.config.models import PortfolioConfig
 from tracer.conversation.analysis_loop import (
@@ -21,6 +22,7 @@ from tracer.conversation.analysis_loop import (
 from tracer.conversation.context import ConversationContext, extract_context, resolve_pronoun
 from tracer.conversation.dispatcher import invoke_tools
 from tracer.conversation.intent import Intent, IntentParser, IntentType
+from tracer.conversation.report_exporter import ReportExporter
 from tracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 from tracer.data.registry import DataRegistry, build_registry
 from tracer.llm.registry import LLMRegistry
@@ -57,6 +59,7 @@ class ConversationEngine:
         max_iterations: int = MAX_ITERATIONS,
         confidence_threshold: float = CONFIDENCE_THRESHOLD,
         session_logger: SessionLogger | None = None,
+        report_dir: Path | None = None,
     ) -> None:
         if data_registry is None:
             data_registry = build_registry()
@@ -75,13 +78,32 @@ class ConversationEngine:
         self._history: list[dict] = []
         self._session_logger = session_logger
         self._compactor = SessionCompactor(llm_registry) if session_logger else None
+        self._report_exporter = ReportExporter(report_dir) if report_dir else None
         self._context: ConversationContext = ConversationContext()
         self._turn_counter = 0
+        self._last_response: EngineResponse | None = None
 
     @property
     def history(self) -> list[dict]:
         """Turn history for the current session."""
         return list(self._history)
+
+    def save_last_report(self, fmt: str = "md") -> Path | None:
+        """Save the last analysis result as a report file.
+
+        Args:
+            fmt: ``"md"`` for Markdown, ``"json"`` for JSON.
+
+        Returns:
+            Path to the saved file, or None if no report exporter is
+            configured or no previous response exists.
+        """
+        if self._report_exporter is None or self._last_response is None:
+            return None
+        resp = self._last_response
+        if fmt == "json":
+            return self._report_exporter.save_json(resp.intent, resp.analysis, resp.text)
+        return self._report_exporter.save_markdown(resp.intent, resp.analysis, resp.text)
 
     def _log_turn(self, role: str, content: str, **kwargs: object) -> None:
         """Append a turn to the session log if a logger is configured."""
@@ -140,10 +162,13 @@ class ConversationEngine:
 
         # 2. Comparison branch: per-ticker analysis + comparison table.
         if intent.intent_type == IntentType.COMPARISON and len(intent.tickers) >= 2:
-            return await self._handle_comparison(intent)
+            response = await self._handle_comparison(intent)
+        else:
+            # 3. Standard analysis path.
+            response = await self._handle_standard(intent)
 
-        # 3. Standard analysis path.
-        return await self._handle_standard(intent)
+        self._last_response = response
+        return response
 
     async def _handle_comparison(self, intent: Intent) -> EngineResponse:
         """Run per-ticker analysis concurrently and synthesize comparison."""

--- a/src/tracer/conversation/report_exporter.py
+++ b/src/tracer/conversation/report_exporter.py
@@ -1,0 +1,157 @@
+"""ReportExporter — saves analysis results to Markdown and JSON files.
+
+Reports are stored in ``~/.qracer/reports/`` with filenames based on
+the primary ticker and date.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from tracer.conversation.analysis_loop import AnalysisResult
+from tracer.conversation.intent import Intent
+
+logger = logging.getLogger(__name__)
+
+
+class ReportExporter:
+    """Exports analysis results to Markdown and/or JSON files.
+
+    Usage::
+
+        exporter = ReportExporter(Path("~/.qracer/reports"))
+        path = exporter.save_markdown(intent, analysis, response_text)
+    """
+
+    def __init__(self, output_dir: Path) -> None:
+        self._output_dir = output_dir
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+
+    def _build_filename(self, intent: Intent, ext: str) -> Path:
+        """Build a filename like AAPL-2026-04-06.md from the intent."""
+        ticker = intent.tickers[0] if intent.tickers else "general"
+        today = datetime.now().strftime("%Y-%m-%d")
+        return self._output_dir / f"{ticker}-{today}{ext}"
+
+    def save_markdown(
+        self,
+        intent: Intent,
+        analysis: AnalysisResult,
+        response_text: str,
+    ) -> Path:
+        """Save the analysis as a Markdown report.
+
+        Returns the path to the saved file.
+        """
+        ticker = intent.tickers[0] if intent.tickers else "general"
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        lines: list[str] = [
+            f"# Analysis Report: {ticker}",
+            f"**Date:** {today}",
+            f"**Query:** {intent.raw_query}",
+            f"**Intent:** {intent.intent_type.value}",
+            f"**Confidence:** {analysis.confidence:.2f}",
+            "",
+            "---",
+            "",
+            "## Response",
+            "",
+            response_text,
+            "",
+        ]
+
+        # Trade thesis section
+        if analysis.trade_thesis is not None:
+            t = analysis.trade_thesis
+            lines.extend(
+                [
+                    "---",
+                    "",
+                    "## Trade Thesis",
+                    "",
+                    f"- **Ticker:** {t.ticker}",
+                    f"- **Entry Zone:** ${t.entry_zone[0]:.2f} – ${t.entry_zone[1]:.2f}",
+                    f"- **Target Price:** ${t.target_price:.2f}",
+                    f"- **Stop Loss:** ${t.stop_loss:.2f}",
+                    f"- **Risk/Reward:** {t.risk_reward_ratio:.2f}",
+                    f"- **Conviction:** {t.conviction}/10",
+                    f"- **Catalyst:** {t.catalyst}",
+                ]
+            )
+            if t.catalyst_date:
+                lines.append(f"- **Catalyst Date:** {t.catalyst_date}")
+            lines.extend(["", t.summary, ""])
+
+        # Data sources used
+        tools_used = [r.tool for r in analysis.results if r.success]
+        if tools_used:
+            lines.extend(
+                [
+                    "---",
+                    "",
+                    "## Data Sources",
+                    "",
+                    *[f"- {tool}" for tool in tools_used],
+                    "",
+                ]
+            )
+
+        path = self._build_filename(intent, ".md")
+        path.write_text("\n".join(lines), encoding="utf-8")
+        logger.info("Report saved: %s", path)
+        return path
+
+    def save_json(
+        self,
+        intent: Intent,
+        analysis: AnalysisResult,
+        response_text: str,
+    ) -> Path:
+        """Save the analysis as a JSON file.
+
+        Returns the path to the saved file.
+        """
+        ticker = intent.tickers[0] if intent.tickers else "general"
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        data: dict = {
+            "ticker": ticker,
+            "date": today,
+            "query": intent.raw_query,
+            "intent": intent.intent_type.value,
+            "confidence": analysis.confidence,
+            "iterations": analysis.iterations,
+            "response": response_text,
+            "tools": [
+                {
+                    "tool": r.tool,
+                    "success": r.success,
+                    "source": r.source,
+                    "data": r.data,
+                }
+                for r in analysis.results
+            ],
+        }
+
+        if analysis.trade_thesis is not None:
+            t = analysis.trade_thesis
+            data["trade_thesis"] = {
+                "ticker": t.ticker,
+                "entry_zone": list(t.entry_zone),
+                "target_price": t.target_price,
+                "stop_loss": t.stop_loss,
+                "risk_reward_ratio": t.risk_reward_ratio,
+                "catalyst": t.catalyst,
+                "catalyst_date": t.catalyst_date,
+                "conviction": t.conviction,
+                "summary": t.summary,
+            }
+
+        path = self._build_filename(intent, ".json")
+        path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        logger.info("Report saved: %s", path)
+        return path

--- a/tests/conversation/test_report_exporter.py
+++ b/tests/conversation/test_report_exporter.py
@@ -1,0 +1,106 @@
+"""Tests for ReportExporter."""
+
+from __future__ import annotations
+
+import json
+
+from tracer.conversation.analysis_loop import AnalysisResult
+from tracer.conversation.intent import Intent, IntentType
+from tracer.conversation.report_exporter import ReportExporter
+from tracer.models import ToolResult, TradeThesis
+
+
+def _intent(tickers: list[str] | None = None) -> Intent:
+    return Intent(
+        intent_type=IntentType.DEEP_DIVE,
+        tickers=tickers or ["AAPL"],
+        raw_query="Analyze AAPL",
+    )
+
+
+def _analysis(with_thesis: bool = False) -> AnalysisResult:
+    results = [
+        ToolResult(tool="price_event", success=True, data={"price": 180.0}, source="test"),
+        ToolResult(tool="news", success=True, data={"count": 3}, source="test"),
+        ToolResult(tool="macro", success=False, data={}, source="test", error="no provider"),
+    ]
+    thesis = None
+    if with_thesis:
+        thesis = TradeThesis(
+            ticker="AAPL",
+            entry_zone=(175.0, 180.0),
+            target_price=200.0,
+            stop_loss=165.0,
+            risk_reward_ratio=2.5,
+            catalyst="AI revenue growth",
+            catalyst_date="Q2 2026",
+            conviction=8,
+            summary="Long AAPL on AI tailwinds.",
+        )
+    return AnalysisResult(results=results, confidence=0.85, iterations=2, trade_thesis=thesis)
+
+
+class TestReportExporterMarkdown:
+    def test_save_basic(self, tmp_path) -> None:
+        exporter = ReportExporter(tmp_path)
+        path = exporter.save_markdown(_intent(), _analysis(), "Analysis text here.")
+        assert path.exists()
+        assert path.suffix == ".md"
+        content = path.read_text()
+        assert "AAPL" in content
+        assert "Analysis text here." in content
+        assert "0.85" in content
+
+    def test_save_with_thesis(self, tmp_path) -> None:
+        exporter = ReportExporter(tmp_path)
+        path = exporter.save_markdown(_intent(), _analysis(with_thesis=True), "Response")
+        content = path.read_text()
+        assert "Trade Thesis" in content
+        assert "$175.00" in content
+        assert "$200.00" in content
+        assert "8/10" in content
+        assert "AI revenue growth" in content
+        assert "Q2 2026" in content
+
+    def test_save_with_data_sources(self, tmp_path) -> None:
+        exporter = ReportExporter(tmp_path)
+        path = exporter.save_markdown(_intent(), _analysis(), "Response")
+        content = path.read_text()
+        assert "Data Sources" in content
+        assert "price_event" in content
+        assert "news" in content
+        # Failed tool (macro) should not appear in data sources
+        assert "macro" not in content.split("Data Sources")[1]
+
+    def test_general_ticker_fallback(self, tmp_path) -> None:
+        exporter = ReportExporter(tmp_path)
+        intent = Intent(intent_type=IntentType.MACRO_QUERY, tickers=[], raw_query="inflation?")
+        path = exporter.save_markdown(intent, _analysis(), "Response")
+        assert "general" in path.name
+
+
+class TestReportExporterJson:
+    def test_save_basic(self, tmp_path) -> None:
+        exporter = ReportExporter(tmp_path)
+        path = exporter.save_json(_intent(), _analysis(), "Analysis text.")
+        assert path.exists()
+        assert path.suffix == ".json"
+        data = json.loads(path.read_text())
+        assert data["ticker"] == "AAPL"
+        assert data["confidence"] == 0.85
+        assert data["response"] == "Analysis text."
+        assert len(data["tools"]) == 3
+
+    def test_save_with_thesis(self, tmp_path) -> None:
+        exporter = ReportExporter(tmp_path)
+        path = exporter.save_json(_intent(), _analysis(with_thesis=True), "Response")
+        data = json.loads(path.read_text())
+        assert "trade_thesis" in data
+        assert data["trade_thesis"]["conviction"] == 8
+        assert data["trade_thesis"]["target_price"] == 200.0
+
+    def test_no_thesis_key_when_none(self, tmp_path) -> None:
+        exporter = ReportExporter(tmp_path)
+        path = exporter.save_json(_intent(), _analysis(with_thesis=False), "Response")
+        data = json.loads(path.read_text())
+        assert "trade_thesis" not in data


### PR DESCRIPTION
## Summary

분석 결과를 Markdown/JSON 파일로 저장하는 기능을 추가합니다 (closes #47).

## User Flow

```text
tracer> Analyze AAPL
[... analysis response ...]

tracer> save
Saved to ~/.qracer/reports/AAPL-2026-04-06.md

tracer> save json
Saved to ~/.qracer/reports/AAPL-2026-04-06.json
```

## Changes

| 파일 | 변경 |
|------|------|
| `src/tracer/conversation/report_exporter.py` | **신규** — ReportExporter (Markdown + JSON) |
| `src/tracer/conversation/engine.py` | `save_last_report()`, `_last_response` 추적, `report_dir` 파라미터 |
| `src/tracer/conversation/__init__.py` | ReportExporter export |
| `src/tracer/cli.py` | `save`/`save json` 명령어, `report_dir` 주입 |
| `tests/conversation/test_report_exporter.py` | **신규** — 7개 테스트 |

## Markdown Output

```markdown
# Analysis Report: AAPL
**Date:** 2026-04-06
**Confidence:** 0.85

## Response
[full analysis text]

## Trade Thesis
- Entry Zone: $175.00 – $180.00
- Target: $200.00
- Conviction: 8/10

## Data Sources
- price_event
- news
```

## Test plan

- [x] 303 passed (기존 296 + 새 7개)
- [x] ruff clean, pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk