### PR TITLE
feat: wire memory_search to real MemorySearcher (closes #63)

### DIFF
--- a/src/qracer/conversation/dispatcher.py
+++ b/src/qracer/conversation/dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from qracer.conversation.intent import Intent
 from qracer.data.registry import DataRegistry
@@ -21,7 +22,13 @@ TOOL_DISPATCH: dict[str, str] = {
 }
 
 
-async def invoke_tool(tool_name: str, intent: Intent, registry: DataRegistry) -> ToolResult:
+async def invoke_tool(
+    tool_name: str,
+    intent: Intent,
+    registry: DataRegistry,
+    *,
+    memory_searcher: Any = None,
+) -> ToolResult:
     """Invoke a single pipeline tool based on the intent context."""
     tickers = intent.tickers
 
@@ -38,7 +45,7 @@ async def invoke_tool(tool_name: str, intent: Intent, registry: DataRegistry) ->
     if tool_name == "macro":
         return await pipeline.macro(intent.raw_query, registry)
     if tool_name == "memory_search":
-        return await pipeline.memory_search(intent.raw_query)
+        return await pipeline.memory_search(intent.raw_query, searcher=memory_searcher)
 
     return ToolResult(
         tool=tool_name,
@@ -50,10 +57,16 @@ async def invoke_tool(tool_name: str, intent: Intent, registry: DataRegistry) ->
 
 
 async def invoke_tools(
-    tool_names: list[str], intent: Intent, registry: DataRegistry
+    tool_names: list[str],
+    intent: Intent,
+    registry: DataRegistry,
+    *,
+    memory_searcher: Any = None,
 ) -> list[ToolResult]:
     """Invoke multiple pipeline tools concurrently."""
     if not tool_names:
         return []
-    coros = [invoke_tool(name, intent, registry) for name in tool_names]
+    coros = [
+        invoke_tool(name, intent, registry, memory_searcher=memory_searcher) for name in tool_names
+    ]
     return list(await asyncio.gather(*coros))

--- a/src/qracer/conversation/engine.py
+++ b/src/qracer/conversation/engine.py
@@ -60,6 +60,7 @@ class ConversationEngine:
         confidence_threshold: float = CONFIDENCE_THRESHOLD,
         session_logger: SessionLogger | None = None,
         report_dir: Path | None = None,
+        memory_searcher: object | None = None,
     ) -> None:
         if data_registry is None:
             data_registry = build_registry()
@@ -79,6 +80,7 @@ class ConversationEngine:
         self._session_logger = session_logger
         self._compactor = SessionCompactor(llm_registry) if session_logger else None
         self._report_exporter = ReportExporter(report_dir) if report_dir else None
+        self._memory_searcher = memory_searcher
         self._context: ConversationContext = ConversationContext()
         self._turn_counter = 0
         self._last_response: EngineResponse | None = None
@@ -182,7 +184,10 @@ class ConversationEngine:
             for ticker in intent.tickers
         ]
         gathered = await asyncio.gather(
-            *[invoke_tools(si.tools, si, self._data) for si in single_intents]
+            *[
+                invoke_tools(si.tools, si, self._data, memory_searcher=self._memory_searcher)
+                for si in single_intents
+            ]
         )
         per_ticker_results: dict[str, list[ToolResult]] = dict(zip(intent.tickers, gathered))
         all_results = [r for results in per_ticker_results.values() for r in results]
@@ -196,7 +201,9 @@ class ConversationEngine:
     async def _handle_standard(self, intent: Intent) -> EngineResponse:
         """Run the standard analysis pipeline (DeepPath)."""
         # Invoke initial pipeline tools.
-        initial_results = await invoke_tools(intent.tools, intent, self._data)
+        initial_results = await invoke_tools(
+            intent.tools, intent, self._data, memory_searcher=self._memory_searcher
+        )
 
         # Run analysis loop.
         analysis = await self._analysis_loop.run(intent, initial_results)

--- a/src/qracer/tools/pipeline.py
+++ b/src/qracer/tools/pipeline.py
@@ -423,18 +423,31 @@ async def risk_check(
         )
 
 
-async def memory_search(query: str, **kwargs: object) -> ToolResult:
+async def memory_search(query: str, searcher: Any = None, **kwargs: object) -> ToolResult:
     """Search past analyses stored in session memory.
 
-    This is a placeholder — the full implementation depends on the SessionManager
-    and memory system which are built in later layers.
+    If a MemorySearcher instance is provided, performs a real FTS search.
+    Otherwise returns empty results (graceful degradation).
     """
-    now = datetime.now()
-    return ToolResult(
-        tool="memory_search",
-        success=True,
-        data={"query": query, "results": []},
-        source="SessionMemory",
-        fetched_at=now,
-        is_stale=False,
-    )
+
+    async def _fetch() -> dict[str, Any]:
+        if searcher is None:
+            return {"query": query, "results": []}
+
+        try:
+            results = searcher.search(query, limit=5)
+            return {
+                "query": query,
+                "results": [
+                    {
+                        "session_id": r.session_id,
+                        "summary": r.summary[:500],
+                        "score": r.score,
+                    }
+                    for r in results
+                ],
+            }
+        except Exception:
+            return {"query": query, "results": []}
+
+    return await _run_tool("memory_search", "SessionMemory", _fetch, label=query, stale_check=False)

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -64,7 +64,7 @@ class TestInvokeTool:
         with patch("qracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.memory_search = AsyncMock(return_value=_ok_result("memory_search"))
             await invoke_tool("memory_search", intent, registry)
-            mock_pipeline.memory_search.assert_called_once_with("what about before?")
+            mock_pipeline.memory_search.assert_called_once_with("what about before?", searcher=None)
 
     async def test_tool_without_tickers_returns_failure(self) -> None:
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=[], raw_query="test")


### PR DESCRIPTION
## Summary

`memory_search()` placeholder를 실제 `MemorySearcher.search()`에 연결합니다 (closes #63).

## Changes

| 파일 | 변경 |
|------|------|
| `src/qracer/tools/pipeline.py` | `memory_search()`가 optional `MemorySearcher`를 받아 실제 FTS 검색 수행 |
| `src/qracer/conversation/dispatcher.py` | `invoke_tool/invoke_tools`에 `memory_searcher` kwarg 전달 |
| `src/qracer/conversation/engine.py` | `ConversationEngine`에 `memory_searcher` 파라미터 추가, invoke 호출 시 전달 |
| `tests/conversation/test_engine.py` | memory_search 테스트 assertion 업데이트 |

## How it works

```
ConversationEngine(memory_searcher=searcher)
  → invoke_tools(..., memory_searcher=searcher)
    → pipeline.memory_search(query, searcher=searcher)
      → searcher.search(query, limit=5)  # real FTS search
      → ToolResult with search results
```

Graceful degradation: `searcher=None`이면 빈 결과 반환 (기존 동작 유지).

## Test plan

- [x] 303 passed
- [x] ruff clean, pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk