### PR TITLE
feat: QuickPath for price_check and quick_news intents (closes #60)

### DIFF
--- a/src/qracer/conversation/engine.py
+++ b/src/qracer/conversation/engine.py
@@ -26,7 +26,8 @@ from qracer.conversation.context import (
     resolve_pronoun,
 )
 from qracer.conversation.dispatcher import invoke_tools
-from qracer.conversation.intent import Intent, IntentParser, IntentType
+from qracer.conversation.intent import QUICKPATH_INTENTS, Intent, IntentParser, IntentType
+from qracer.conversation.quickpath import format_quickpath
 from qracer.conversation.report_exporter import ReportExporter
 from qracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 from qracer.data.registry import DataRegistry, build_registry
@@ -199,15 +200,29 @@ class ConversationEngine:
             intent.tools,
         )
 
-        # 2. Comparison branch: per-ticker analysis + comparison table.
-        if intent.intent_type == IntentType.COMPARISON and len(intent.tickers) >= 2:
+        # 2. QuickPath: template-based response, no AnalysisLoop.
+        if intent.intent_type in QUICKPATH_INTENTS:
+            response = await self._handle_quickpath(intent)
+        # 3. Comparison branch: per-ticker analysis + comparison table.
+        elif intent.intent_type == IntentType.COMPARISON and len(intent.tickers) >= 2:
             response = await self._handle_comparison(intent)
         else:
-            # 3. Standard analysis path.
+            # 4. Standard analysis path (DeepPath).
             response = await self._handle_standard(intent)
 
         self._last_response = response
         return response
+
+    async def _handle_quickpath(self, intent: Intent) -> EngineResponse:
+        """QuickPath: fetch 1-2 tools, format with template, no LLM."""
+        results = await invoke_tools(
+            intent.tools, intent, self._data, memory_searcher=self._memory_searcher
+        )
+        text = format_quickpath(intent, results)
+        analysis = AnalysisResult(results=results, confidence=1.0, iterations=0)
+        self._history.append({"role": "assistant", "content": text})
+        self._log_turn("assistant", text)
+        return EngineResponse(text=text, intent=intent, analysis=analysis)
 
     async def _handle_comparison(self, intent: Intent) -> EngineResponse:
         """Run per-ticker analysis concurrently and synthesize comparison."""

--- a/src/qracer/conversation/intent.py
+++ b/src/qracer/conversation/intent.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 class IntentType(str, Enum):
     """Supported intent types from the conversational-layer spec."""
 
+    # QuickPath intents (< 5s, 0-1 LLM calls)
+    PRICE_CHECK = "price_check"
+    QUICK_NEWS = "quick_news"
+    # DeepPath intents (30-120s, 3-7 LLM calls)
     EVENT_ANALYSIS = "event_analysis"
     DEEP_DIVE = "deep_dive"
     ALPHA_HUNT = "alpha_hunt"
@@ -29,8 +33,13 @@ class IntentType(str, Enum):
     COMPARISON = "comparison"
 
 
+# Intents that use the QuickPath (no AnalysisLoop).
+QUICKPATH_INTENTS = frozenset({IntentType.PRICE_CHECK, IntentType.QUICK_NEWS})
+
 # Which pipeline tools each intent invokes by default.
 INTENT_TOOL_MAP: dict[IntentType, list[str]] = {
+    IntentType.PRICE_CHECK: ["price_event"],
+    IntentType.QUICK_NEWS: ["news"],
     IntentType.EVENT_ANALYSIS: ["price_event", "news", "insider", "cross_market"],
     IntentType.DEEP_DIVE: [
         "price_event",
@@ -65,11 +74,13 @@ class Intent:
 _SYSTEM_PROMPT = """\
 You are a query classifier for a financial analysis system.
 Given a user query, return a JSON object with:
-- "intent": one of event_analysis, deep_dive, alpha_hunt, macro_query, \
-cross_market, follow_up, comparison
+- "intent": one of price_check, quick_news, event_analysis, deep_dive, \
+alpha_hunt, macro_query, cross_market, follow_up, comparison
 - "tickers": list of stock tickers mentioned (uppercase, empty list if none)
 
 Rules:
+- "What's AAPL at?", "Price of X", "How's X doing?" → price_check
+- "Any news on X?", "News for X" → quick_news
 - "Why did X move/spike/drop" → event_analysis
 - "Full analysis on X" or "Tell me about X" → deep_dive
 - "Where's alpha" or "hidden opportunities" → alpha_hunt
@@ -125,6 +136,17 @@ class IntentParser:
 
         # Extract uppercase tickers (simple heuristic: 1-5 letter uppercase words).
         tickers = _extract_tickers(query)
+
+        # QuickPath: simple price check (single ticker, short query).
+        if tickers and any(
+            w in q
+            for w in ("price", "what's", "whats", "how's", "hows", "how much", "quote", "at?")
+        ):
+            return Intent(IntentType.PRICE_CHECK, tickers=tickers, raw_query=query)
+
+        # QuickPath: news lookup.
+        if tickers and any(w in q for w in ("news", "headlines", "latest on")):
+            return Intent(IntentType.QUICK_NEWS, tickers=tickers, raw_query=query)
 
         # Comparison must be checked first — "Compare AAPL spike" should be comparison.
         if len(tickers) >= 2 and any(w in q for w in ("compare", " vs ", "versus")):

--- a/src/qracer/conversation/quickpath.py
+++ b/src/qracer/conversation/quickpath.py
@@ -1,0 +1,106 @@
+"""QuickPath formatter — template-based responses without LLM calls.
+
+Produces compact, terminal-friendly output for simple queries like
+price checks and news lookups.  Target: < 5 seconds end-to-end.
+"""
+
+from __future__ import annotations
+
+from qracer.conversation.intent import Intent, IntentType
+from qracer.models import ToolResult
+
+
+def format_quickpath(intent: Intent, results: list[ToolResult]) -> str:
+    """Format tool results into a compact template response.
+
+    No LLM call required — pure string formatting.
+    """
+    if intent.intent_type == IntentType.PRICE_CHECK:
+        return _format_price_check(intent, results)
+    if intent.intent_type == IntentType.QUICK_NEWS:
+        return _format_quick_news(intent, results)
+    return _format_generic(intent, results)
+
+
+def _format_price_check(intent: Intent, results: list[ToolResult]) -> str:
+    """Format price data into a compact one-liner."""
+    ticker = intent.tickers[0] if intent.tickers else "?"
+    price_result = next((r for r in results if r.tool == "price_event" and r.success), None)
+
+    if price_result is None:
+        return f"{ticker}: price unavailable"
+
+    data = price_result.data
+    price = data.get("current_price")
+    bars = data.get("ohlcv", [])
+
+    if price is None:
+        return f"{ticker}: price unavailable"
+
+    parts = [f"{ticker}: ${price:,.2f}"]
+
+    # Calculate day change from latest OHLCV bar if available.
+    if bars:
+        latest = bars[-1]
+        prev_close = latest.get("open", price)
+        if prev_close and prev_close > 0:
+            change = price - prev_close
+            change_pct = (change / prev_close) * 100
+            sign = "+" if change >= 0 else ""
+            parts.append(f"{sign}{change_pct:.1f}%")
+
+        # Volume
+        vol = latest.get("volume")
+        if vol:
+            if vol >= 1_000_000:
+                parts.append(f"Vol: {vol / 1_000_000:.1f}M")
+            elif vol >= 1_000:
+                parts.append(f"Vol: {vol / 1_000:.0f}K")
+
+        # Day range
+        high = latest.get("high")
+        low = latest.get("low")
+        if high and low:
+            parts.append(f"Range: {low:.2f}–{high:.2f}")
+
+    return " | ".join(parts)
+
+
+def _format_quick_news(intent: Intent, results: list[ToolResult]) -> str:
+    """Format news articles into a brief list."""
+    ticker = intent.tickers[0] if intent.tickers else "?"
+    news_result = next((r for r in results if r.tool == "news" and r.success), None)
+
+    if news_result is None:
+        return f"{ticker}: no news available"
+
+    articles = news_result.data.get("articles", [])
+    if not articles:
+        return f"{ticker}: no recent news"
+
+    lines = [f"News for {ticker} ({len(articles)} articles):"]
+    for a in articles[:5]:
+        title = a.get("title", "Untitled")
+        source = a.get("source", "")
+        sentiment = a.get("sentiment")
+        sentiment_str = ""
+        if sentiment is not None:
+            if sentiment > 0.3:
+                sentiment_str = " [+]"
+            elif sentiment < -0.3:
+                sentiment_str = " [-]"
+        src = f" ({source})" if source else ""
+        lines.append(f"  - {title}{src}{sentiment_str}")
+
+    return "\n".join(lines)
+
+
+def _format_generic(intent: Intent, results: list[ToolResult]) -> str:
+    """Fallback for unhandled QuickPath intents."""
+    successful = [r for r in results if r.success]
+    if not successful:
+        return "No data available."
+    parts = []
+    for r in successful:
+        parts.append(f"[{r.tool}] {r.source}: {len(r.data)} fields")
+    return "\n".join(parts)

--- a/tests/conversation/test_quickpath.py
+++ b/tests/conversation/test_quickpath.py
@@ -1,0 +1,137 @@
+"""Tests for QuickPath template formatting."""
+
+from __future__ import annotations
+
+from qracer.conversation.intent import Intent, IntentType
+from qracer.conversation.quickpath import format_quickpath
+from qracer.models import ToolResult
+
+
+def _price_result(ticker: str = "AAPL", price: float = 178.52) -> ToolResult:
+    return ToolResult(
+        tool="price_event",
+        success=True,
+        data={
+            "ticker": ticker,
+            "current_price": price,
+            "bars": 1,
+            "ohlcv": [
+                {
+                    "date": "2026-04-06",
+                    "open": 176.20,
+                    "high": 179.10,
+                    "low": 175.50,
+                    "close": 178.52,
+                    "volume": 52_000_000,
+                }
+            ],
+        },
+        source="PriceProvider",
+    )
+
+
+def _news_result(ticker: str = "AAPL") -> ToolResult:
+    return ToolResult(
+        tool="news",
+        success=True,
+        data={
+            "ticker": ticker,
+            "count": 2,
+            "articles": [
+                {
+                    "title": "AAPL beats earnings estimates",
+                    "source": "Reuters",
+                    "sentiment": 0.8,
+                },
+                {
+                    "title": "iPhone sales slow in China",
+                    "source": "Bloomberg",
+                    "sentiment": -0.5,
+                },
+            ],
+        },
+        source="NewsProvider",
+    )
+
+
+class TestPriceCheck:
+    def test_basic_price(self) -> None:
+        intent = Intent(IntentType.PRICE_CHECK, tickers=["AAPL"], raw_query="What's AAPL at?")
+        text = format_quickpath(intent, [_price_result()])
+        assert "AAPL" in text
+        assert "$178.52" in text
+
+    def test_includes_change_and_volume(self) -> None:
+        intent = Intent(IntentType.PRICE_CHECK, tickers=["AAPL"], raw_query="AAPL price")
+        text = format_quickpath(intent, [_price_result()])
+        assert "%" in text
+        assert "Vol:" in text
+        assert "Range:" in text
+
+    def test_price_unavailable(self) -> None:
+        intent = Intent(IntentType.PRICE_CHECK, tickers=["AAPL"], raw_query="AAPL price")
+        failed = ToolResult(
+            tool="price_event", success=False, data={}, source="test", error="no provider"
+        )
+        text = format_quickpath(intent, [failed])
+        assert "unavailable" in text
+
+
+class TestQuickNews:
+    def test_basic_news(self) -> None:
+        intent = Intent(IntentType.QUICK_NEWS, tickers=["AAPL"], raw_query="News on AAPL")
+        text = format_quickpath(intent, [_news_result()])
+        assert "AAPL" in text
+        assert "beats earnings" in text
+        assert "Reuters" in text
+
+    def test_sentiment_indicators(self) -> None:
+        intent = Intent(IntentType.QUICK_NEWS, tickers=["AAPL"], raw_query="News AAPL")
+        text = format_quickpath(intent, [_news_result()])
+        assert "[+]" in text  # positive sentiment
+        assert "[-]" in text  # negative sentiment
+
+    def test_no_news(self) -> None:
+        intent = Intent(IntentType.QUICK_NEWS, tickers=["AAPL"], raw_query="News AAPL")
+        failed = ToolResult(tool="news", success=False, data={}, source="test", error="no provider")
+        text = format_quickpath(intent, [failed])
+        assert "no news" in text
+
+
+class TestKeywordDetection:
+    def test_price_check_keywords(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from qracer.conversation.intent import IntentParser, IntentType
+        from qracer.llm.providers import Role
+        from qracer.llm.registry import LLMRegistry
+
+        # Use failing LLM to trigger keyword fallback
+        mock = AsyncMock()
+        mock.complete.side_effect = RuntimeError("fail")
+        registry = LLMRegistry()
+        registry.register("mock", mock, [Role.RESEARCHER])
+        parser = IntentParser(registry)
+
+        import asyncio
+
+        intent = asyncio.get_event_loop().run_until_complete(parser.parse("What's AAPL at?"))
+        assert intent.intent_type == IntentType.PRICE_CHECK
+
+    def test_quick_news_keywords(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from qracer.conversation.intent import IntentParser, IntentType
+        from qracer.llm.providers import Role
+        from qracer.llm.registry import LLMRegistry
+
+        mock = AsyncMock()
+        mock.complete.side_effect = RuntimeError("fail")
+        registry = LLMRegistry()
+        registry.register("mock", mock, [Role.RESEARCHER])
+        parser = IntentParser(registry)
+
+        import asyncio
+
+        intent = asyncio.get_event_loop().run_until_complete(parser.parse("Any news on TSLA?"))
+        assert intent.intent_type == IntentType.QUICK_NEWS


### PR DESCRIPTION
## Summary

QuickPath (LivePipeline)를 구현합니다 (closes #60). 간단한 쿼리는 AnalysisLoop과 LLM 호출 없이 템플릿으로 즉시 응답합니다.

## QuickPath vs DeepPath

| | QuickPath | DeepPath |
|---|---|---|
| **When** | price_check, quick_news | event_analysis, deep_dive, etc. |
| **LLM calls** | 0 | 3-7 |
| **Latency** | < 5s | 30-120s |
| **Output** | Template-formatted | Full analysis report |

## Examples

```
qracer> What's AAPL at?
AAPL: $178.52 | +1.3% | Vol: 52.0M | Range: 175.50–179.10

qracer> News on TSLA
News for TSLA (2 articles):
  - TSLA beats delivery estimates (Reuters) [+]
  - FSD recall announced (Bloomberg) [-]
```

## Changes

| 파일 | 변경 |
|------|------|
| `src/qracer/conversation/intent.py` | `PRICE_CHECK`, `QUICK_NEWS` 인텐트 + `QUICKPATH_INTENTS` + keyword 감지 |
| `src/qracer/conversation/quickpath.py` | **신규** — template formatter (price, news) |
| `src/qracer/conversation/engine.py` | QuickPath 라우팅 (`_handle_quickpath`) |
| `tests/conversation/test_quickpath.py` | **신규** — 8개 테스트 |

## Test plan

- [x] 323 passed (기존 315 + 새 8개)
- [x] ruff clean, pyright 0 errors

https://claude.ai/code/session_01C1pbAL7nJ6JvbbGTyeT4Wk