### PR TITLE
feat: interactive LLM provider selection in install

### DIFF
--- a/src/qracer/cli.py
+++ b/src/qracer/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -44,25 +45,39 @@ def main(ctx: click.Context) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _collect_credential_prompts() -> list[tuple[str, str]]:
-    """Collect credential prompts from providers.toml (api_key_env fields).
+_LLM_DISPLAY_NAMES: dict[str, str] = {
+    "claude": "Claude (Anthropic)",
+    "openai": "OpenAI (GPT-4o)",
+    "gemini": "Gemini (Google)",
+}
 
-    Reads the schema defaults and any existing user config to discover
-    which providers declare an ``api_key_env``.  Returns a list of
-    ``(ENV_VAR_NAME, human label)`` pairs.
-    """
+
+def _collect_llm_choices() -> list[tuple[str, str, str | None]]:
+    """Return ``[(name, display_label, api_key_env), ...]`` for LLM providers."""
     schema_data = _load_toml(SCHEMA_DIR / "providers.toml")
-    user_data = _load_toml(_user_dir() / "providers.toml")
-    merged = {
-        **schema_data.get("providers", {}),
-        **user_data.get("providers", {}),
-    }
-    result: list[tuple[str, str]] = []
-    for name, cfg in merged.items():
-        env_key = cfg.get("api_key_env")
-        if env_key:
-            result.append((env_key, f"{name} — {env_key}"))
+    result: list[tuple[str, str, str | None]] = []
+    for name, cfg in schema_data.get("providers", {}).items():
+        if cfg.get("kind") == "llm":
+            label = _LLM_DISPLAY_NAMES.get(name) or name.capitalize()
+            env: str | None = cfg.get("api_key_env")
+            result.append((name, label, env))
     return result
+
+
+def _update_provider_selection(
+    providers_path: Path,
+    chosen: str,
+    all_llm: list[tuple[str, str, str | None]],
+) -> None:
+    """Enable the chosen LLM provider and disable others in providers.toml."""
+    if not providers_path.exists():
+        return
+    text = providers_path.read_text(encoding="utf-8")
+    for name, _, _ in all_llm:
+        enable = "true" if name == chosen else "false"
+        pattern = rf"(\[providers\.{re.escape(name)}\][^\[]*?)enabled\s*=\s*(true|false)"
+        text = re.sub(pattern, rf"\1enabled = {enable}", text)
+    providers_path.write_text(text, encoding="utf-8")
 
 
 @main.command()
@@ -84,24 +99,34 @@ def install() -> None:
             shutil.copy2(src, dest)
             click.echo(f"  Created {name}")
 
-    # 3. Prompt for credentials
-    click.echo()
-    creds: dict[str, str] = {}
-    for env_key, label in _collect_credential_prompts():
-        value = click.prompt(f"  {label}", default="", show_default=False).strip()
-        if value:
-            creds[env_key] = value
+    # 3. LLM provider selection
+    llm_choices = _collect_llm_choices()
+    click.echo("\n  Select LLM provider:")
+    for i, (_, label, _) in enumerate(llm_choices, 1):
+        click.echo(f"    {i}. {label}")
 
-    # 4. Prompt for portfolio currency
+    choice_idx = click.prompt("  Choice", type=click.IntRange(1, len(llm_choices)), default=1)
+    chosen_name, chosen_label, chosen_env = llm_choices[choice_idx - 1]
+
+    # 4. Prompt for the chosen provider's API key only
+    creds: dict[str, str] = {}
+    if chosen_env:
+        value = click.prompt(f"\n  {chosen_env}", default="", show_default=False).strip()
+        if value:
+            creds[chosen_env] = value
+
+    # 5. Prompt for portfolio currency
     currency = click.prompt("\n  Portfolio currency", default="USD").strip()
 
-    # 5. Write credentials.env
+    # 6. Write credentials.env
     creds_path = home_dir / "credentials.env"
     lines = [f"{k}={v}" for k, v in creds.items()]
     creds_path.write_text("\n".join(lines) + "\n" if lines else "")
-    click.echo(f"\n  Written {creds_path}")
 
-    # 6. Update portfolio currency if non-default
+    # 7. Enable chosen LLM provider in providers.toml
+    _update_provider_selection(home_dir / "providers.toml", chosen_name, llm_choices)
+
+    # 8. Update portfolio currency if non-default
     if currency != "USD":
         portfolio_path = home_dir / "portfolio.toml"
         if portfolio_path.exists():
@@ -109,18 +134,14 @@ def install() -> None:
             text = text.replace('currency = "USD"', f'currency = "{currency}"')
             portfolio_path.write_text(text, encoding="utf-8")
 
-    click.echo("\n✓ Setup complete!")
+    click.echo(f"\n✓ Setup complete! {chosen_label} enabled as LLM provider.")
 
-    # Warn about missing LLM credentials
-    if not creds.get("ANTHROPIC_API_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
-        click.echo(
-            "\n⚠ ANTHROPIC_API_KEY not set — LLM features will not work."
-            "\n  Set it via 'export ANTHROPIC_API_KEY=your-key' or re-run 'qracer install'."
-        )
+    # Warn if API key was not provided
+    if chosen_env and not creds.get(chosen_env) and not os.environ.get(chosen_env):
+        click.echo(f"\n⚠ {chosen_env} not set — set it before running 'qracer repl'.")
 
     click.echo("\nNext steps:")
     click.echo("  qracer status   — check configuration")
-    click.echo("  qracer config   — view merged config")
     click.echo("  qracer repl     — start interactive session")
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -33,8 +33,8 @@ class TestInstall:
         runner = CliRunner()
 
         with patch("qracer.cli._user_dir", return_value=home_dir):
-            # 3 credential prompts (ANTHROPIC, OPENAI, GOOGLE) + currency
-            result = runner.invoke(main, ["install"], input="\n\n\nUSD\n")
+            # Choice=1 (Claude), skip API key, currency=USD
+            result = runner.invoke(main, ["install"], input="1\n\nUSD\n")
 
         assert result.exit_code == 0
         assert home_dir.is_dir()
@@ -51,7 +51,7 @@ class TestInstall:
 
         runner = CliRunner()
         with patch("qracer.cli._user_dir", return_value=home_dir):
-            result = runner.invoke(main, ["install"], input="\n\n\nUSD\n")
+            result = runner.invoke(main, ["install"], input="1\n\nUSD\n")
 
         assert result.exit_code == 0
         assert "already exists" in result.output
@@ -63,8 +63,8 @@ class TestInstall:
         runner = CliRunner()
 
         with patch("qracer.cli._user_dir", return_value=home_dir):
-            # First prompt is ANTHROPIC_API_KEY, skip OPENAI and GOOGLE
-            result = runner.invoke(main, ["install"], input="sk-ant-key123\n\n\nUSD\n")
+            # Choice=1 (Claude), enter API key
+            result = runner.invoke(main, ["install"], input="1\nsk-ant-key123\nUSD\n")
 
         assert result.exit_code == 0
         creds = (home_dir / "credentials.env").read_text()
@@ -75,12 +75,34 @@ class TestInstall:
         runner = CliRunner()
 
         with patch("qracer.cli._user_dir", return_value=home_dir):
-            # Skip all credential prompts, set currency to EUR
-            result = runner.invoke(main, ["install"], input="\n\n\nEUR\n")
+            # Choice=1 (Claude), skip API key, currency=EUR
+            result = runner.invoke(main, ["install"], input="1\n\nEUR\n")
 
         assert result.exit_code == 0
         portfolio = (home_dir / "portfolio.toml").read_text(encoding="utf-8")
         assert 'currency = "EUR"' in portfolio
+
+    def test_install_selects_openai(self, tmp_path: Path) -> None:
+        home_dir = tmp_path / ".qracer"
+        runner = CliRunner()
+
+        with patch("qracer.cli._user_dir", return_value=home_dir):
+            # Choice=2 (OpenAI), enter API key
+            result = runner.invoke(main, ["install"], input="2\nsk-openai-key\nUSD\n")
+
+        assert result.exit_code == 0
+        # Credentials should have OPENAI_API_KEY
+        creds = (home_dir / "credentials.env").read_text()
+        assert "OPENAI_API_KEY=sk-openai-key" in creds
+        # providers.toml should have openai enabled, claude disabled
+        assert "OpenAI" in result.output
+        # Verify provider enablement via config loading
+        import tomllib
+
+        with open(home_dir / "providers.toml", "rb") as f:
+            data = tomllib.load(f)
+        assert data["providers"]["openai"]["enabled"] is True
+        assert data["providers"]["claude"]["enabled"] is False
 
 
 class TestStatus:


### PR DESCRIPTION
## Summary
- `qracer install`에서 **LLM 프로바이더 선택 메뉴** 추가
- 선택한 프로바이더의 **API 키만** 물어봄 (3개 다 물어보던 것 대신)
- 선택한 프로바이더를 `providers.toml`에서 **자동 enable** (나머지 disable)

## Before → After
```
# Before: 3개 키 전부 물어봄
  claude — ANTHROPIC_API_KEY:
  openai — OPENAI_API_KEY:
  gemini — GOOGLE_API_KEY:

# After: 선택 → 해당 키만
  Select LLM provider:
    1. Claude (Anthropic)
    2. OpenAI (GPT-4o)
    3. Gemini (Google)
  Choice [1]: 2

  OPENAI_API_KEY: sk-xxx...

✓ Setup complete! OpenAI (GPT-4o) enabled as LLM provider.
```

## Test plan
- [x] 기존 install 테스트 통과 (입력 형식 업데이트)
- [x] 새 테스트: OpenAI 선택 시 credentials.env + providers.toml 검증
- [x] 전체 373 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)