### PR TITLE
feat: Finnhub data provider (fundamentals, news, insider)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 [project.optional-dependencies]
 openai = ["openai>=1.0.0"]
 gemini = ["google-generativeai>=0.8.0"]
+finnhub = ["finnhub-python>=2.4.0"]
 all-llm = ["openai>=1.0.0", "google-generativeai>=0.8.0"]
 
 [dependency-groups]

--- a/src/qracer/cli.py
+++ b/src/qracer/cli.py
@@ -292,7 +292,13 @@ def _build_registries() -> tuple:  # type: ignore[type-arg]
             try:
                 mod_path, cls_name = adapter_path.rsplit(".", 1)
                 adapter_cls = getattr(importlib.import_module(mod_path), cls_name)
-                adapter = adapter_cls()
+                # Inject API key from credentials if declared
+                api_key = None
+                if prov_cfg.api_key_env:
+                    api_key = config.credentials.get(prov_cfg.api_key_env) or os.environ.get(
+                        prov_cfg.api_key_env
+                    )
+                adapter = adapter_cls(api_key=api_key) if api_key else adapter_cls()
                 caps = []
                 for cp in cap_paths:
                     cp_mod, cp_name = cp.rsplit(".", 1)

--- a/src/qracer/config/schema/providers.toml
+++ b/src/qracer/config/schema/providers.toml
@@ -25,12 +25,12 @@ priority = 50
 kind = "llm"
 api_key_env = "GOOGLE_API_KEY"
 
-# [providers.finnhub]
-# enabled = false
-# priority = 50
-# tier = "warm"
-# kind = "data"
-# api_key_env = "FINNHUB_API_KEY"
+[providers.finnhub]
+enabled = false
+priority = 50
+tier = "warm"
+kind = "data"
+api_key_env = "FINNHUB_API_KEY"
 
 # [providers.fred]
 # enabled = false

--- a/src/qracer/data/finnhub_adapter.py
+++ b/src/qracer/data/finnhub_adapter.py
@@ -1,0 +1,132 @@
+"""FinnhubAdapter — Fundamental, News, and Alternative data via Finnhub API.
+
+Provides three capabilities:
+- FundamentalProvider → PE, market cap, revenue, earnings, dividend yield, sector
+- NewsProvider → company news articles with metadata
+- AlternativeProvider → insider trading records
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime, timedelta
+
+from qracer.data.providers import (
+    AlternativeRecord,
+    FundamentalData,
+    NewsArticle,
+)
+
+try:
+    import finnhub  # pyright: ignore[reportMissingImports]
+
+    _HAS_FINNHUB = True
+except ImportError:
+    _HAS_FINNHUB = False
+
+# Default lookback for news queries.
+_NEWS_LOOKBACK_DAYS = 30
+
+
+def _fetch_fundamentals(client: object, ticker: str) -> FundamentalData:
+    """Synchronous helper — runs in a thread via asyncio.to_thread."""
+    profile = client.company_profile2(symbol=ticker)  # type: ignore[union-attr]
+    metrics_resp = client.company_basic_financials(ticker, "all")  # type: ignore[union-attr]
+    metrics: dict = metrics_resp.get("metric", {}) if metrics_resp else {}
+
+    return FundamentalData(
+        ticker=ticker,
+        pe_ratio=metrics.get("peNormalizedAnnual"),
+        market_cap=profile.get("marketCapitalization"),
+        revenue=metrics.get("revenuePerShareTTM"),
+        earnings=metrics.get("epsNormalizedAnnual"),
+        dividend_yield=metrics.get("dividendYieldIndicatedAnnual"),
+        sector=profile.get("finnhubIndustry"),
+        fetched_at=datetime.now(),
+    )
+
+
+def _fetch_news(client: object, ticker: str, limit: int) -> list[NewsArticle]:
+    """Synchronous helper — runs in a thread via asyncio.to_thread."""
+    end = date.today()
+    start = end - timedelta(days=_NEWS_LOOKBACK_DAYS)
+    articles_raw = client.company_news(  # type: ignore[union-attr]
+        ticker, _from=start.isoformat(), to=end.isoformat()
+    )
+    if not articles_raw:
+        return []
+
+    articles: list[NewsArticle] = []
+    for item in articles_raw[:limit]:
+        published_at = datetime.fromtimestamp(item.get("datetime", 0))
+        articles.append(
+            NewsArticle(
+                title=item.get("headline", ""),
+                source=item.get("source", ""),
+                published_at=published_at,
+                url=item.get("url", ""),
+                summary=item.get("summary", ""),
+                sentiment=None,
+            )
+        )
+    return articles
+
+
+def _fetch_insider(client: object, ticker: str) -> list[AlternativeRecord]:
+    """Synchronous helper — runs in a thread via asyncio.to_thread."""
+    end = date.today()
+    start = end - timedelta(days=90)
+    resp = client.stock_insider_transactions(  # type: ignore[union-attr]
+        ticker, start.isoformat(), end.isoformat()
+    )
+    records_raw = resp.get("data", []) if resp else []
+
+    records: list[AlternativeRecord] = []
+    for item in records_raw:
+        tx_date = item.get("transactionDate", "")
+        try:
+            parsed_date = date.fromisoformat(tx_date) if tx_date else end
+        except ValueError:
+            parsed_date = end
+
+        records.append(
+            AlternativeRecord(
+                record_type="insider_trades",
+                ticker=ticker,
+                data={
+                    "name": item.get("name", ""),
+                    "share": item.get("share", 0),
+                    "change": item.get("change", 0),
+                    "transaction_code": item.get("transactionCode", ""),
+                    "filing_date": item.get("filingDate", ""),
+                },
+                source="finnhub",
+                date=parsed_date,
+            )
+        )
+    return records
+
+
+class FinnhubAdapter:
+    """Data adapter for Finnhub (Fundamentals, News, Alternative data)."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        if not _HAS_FINNHUB:
+            raise ImportError(
+                "finnhub-python is not installed. Install it with: uv add finnhub-python"
+            )
+        self._client = finnhub.Client(api_key=api_key or "")
+
+    async def get_fundamentals(self, ticker: str) -> FundamentalData:
+        """Get fundamental financial data for a ticker."""
+        return await asyncio.to_thread(_fetch_fundamentals, self._client, ticker)
+
+    async def get_news(self, ticker: str, limit: int = 10) -> list[NewsArticle]:
+        """Get recent news articles for a ticker."""
+        return await asyncio.to_thread(_fetch_news, self._client, ticker, limit)
+
+    async def get_alternative(self, ticker: str, record_type: str) -> list[AlternativeRecord]:
+        """Get alternative data records for a ticker."""
+        if record_type == "insider_trades":
+            return await asyncio.to_thread(_fetch_insider, self._client, ticker)
+        return []

--- a/src/qracer/data/yfinance_adapter.py
+++ b/src/qracer/data/yfinance_adapter.py
@@ -64,7 +64,7 @@ class YfinanceAdapter:
 
     capabilities: list = [PriceProvider]
 
-    def __init__(self) -> None:
+    def __init__(self, api_key: str | None = None) -> None:
         if not _HAS_YFINANCE:
             raise ImportError("yfinance is not installed. Install it with: uv add yfinance")
 

--- a/src/qracer/provider_catalog.py
+++ b/src/qracer/provider_catalog.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 BUILTIN_DATA_PROVIDERS: dict[str, tuple[str, list[str]]] = {
     "yfinance": (
         "qracer.data.yfinance_adapter.YfinanceAdapter",
+        ["qracer.data.providers.PriceProvider"],
+    ),
+    "finnhub": (
+        "qracer.data.finnhub_adapter.FinnhubAdapter",
         [
-            "qracer.data.providers.PriceProvider",
             "qracer.data.providers.FundamentalProvider",
             "qracer.data.providers.NewsProvider",
+            "qracer.data.providers.AlternativeProvider",
         ],
     ),
 }


### PR DESCRIPTION
## Summary
- **FinnhubAdapter** 추가 — 3개 데이터 프로토콜 구현으로 에이전트 파이프라인 핵심 단계 언블록
  - `FundamentalProvider`: PE, 시총, 매출, 이익, 배당률, 섹터
  - `NewsProvider`: 기사 제목, 출처, 날짜, URL, 요약
  - `AlternativeProvider`: 내부자 거래 기록
- **yfinance 카탈로그 수정** — FundamentalProvider/NewsProvider 거짓 선언 제거
- **Data adapter api_key 주입** — LLM과 동일 패턴으로 credentials 전달

## Impact
```
Before: 5개 프로토콜 중 1개(Price)만 동작 → 에이전트 분석 대부분 실패
After:  4개(Price, Fundamental, News, Alternative) 동작 → 핵심 분석 가능
```

## How to enable
```bash
uv sync --extra finnhub
```
```toml
# ~/.qracer/providers.toml
[providers.finnhub]
enabled = true
```

## Test plan
- [x] 기존 테스트 통과 (399 passed)
- [x] ruff lint + format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)