### PR TITLE
docs: fix outdated names and mark unimplemented features

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Dual-Mode Design
 
-Tracer operates in two modes based on context:
+qracer operates in two modes based on context:
 
 | | Live Mode | Research Mode |
 |---|---|---|
@@ -77,6 +77,8 @@ Project-local and user configs merge per file: `./.qracer/providers.toml` define
 
 ## Provider Plugin System
 
+> **구현 예정** — 현재는 `provider_catalog.py` 기반 하드코딩 방식으로 동작합니다.
+
 Built-in adapters and external plugins share the same `ProviderPlugin` protocol. Lifecycle methods (`initialize`, `health_check`, `shutdown`) require DataRegistry updates — tracked separately from current implementation.
 
 ```python
@@ -142,12 +144,14 @@ terminal_port = 8194
 
 ## Real-Time Data
 
-For Live Mode, Tracer needs sub-second price data and streaming news:
+> **구현 예정** — WebSocket 실시간 데이터는 아직 구현되지 않았습니다. 현재는 REST polling만 지원합니다.
+
+For Live Mode, qracer needs sub-second price data and streaming news:
 
 | Capability | Preferred Provider | Protocol | Fallback |
 |---|---|---|---|
-| Real-time quotes | Finnhub | WebSocket | REST polling (5s interval) |
-| Streaming news | Finnhub | WebSocket | REST polling (30s interval) |
+| Real-time quotes (구현 예정) | Finnhub | WebSocket | REST polling (5s interval) |
+| Streaming news (구현 예정) | Finnhub | WebSocket | REST polling (30s interval) |
 | Price/OHLCV | Finnhub | REST | yfinance |
 | Fundamental | Finnhub | REST | FMP, yfinance |
 | Macro | FRED | REST | World Bank |
@@ -165,12 +169,12 @@ API key missing → adapter auto-skipped. Fallback kicks in transparently. Provi
 
 ## Storage
 
-DuckDB single-file database (`tracer.db`). Append-only for market data, analytical queries optimized.
+DuckDB single-file database (`qracer.db`). Append-only for market data, analytical queries optimized.
 
 ```text
-DuckDB (tracer.db)
+DuckDB (qracer.db)
 ├── prices             - OHLCV time series (daily append)
-├── prices_intraday    - tick/1min data during live sessions (ephemeral, pruned daily)
+├── prices_intraday    - tick/1min data during live sessions (구현 예정)
 ├── fundamentals       - valuation, financial statements (quarterly append)
 ├── macro              - economic indicators (monthly append)
 ├── news               - articles + sentiment scores (daily append)
@@ -178,9 +182,9 @@ DuckDB (tracer.db)
 ├── signals            - generated signal history
 ├── reports            - analysis report metadata
 ├── agent_logs         - agent execution logs
-├── session_index      - session summary metadata + FTS index
-├── session_embeddings - session summary embeddings + HNSW index
-└── alerts             - active alert rules and trigger history
+├── session_index      - session summary metadata + FTS index (구현 예정)
+├── session_embeddings - session summary embeddings + HNSW index (구현 예정)
+└── alerts             - active alert rules and trigger history (구현 예정)
 ```
 
 Also serves as API cache to reduce rate limit pressure. Export to Parquet for backup/sharing.

--- a/docs/autonomous-mode.md
+++ b/docs/autonomous-mode.md
@@ -1,6 +1,8 @@
 # Autonomous Mode
 
-Tracer runs autonomously during market hours — monitoring watchlists, detecting significant events, and proactively alerting users without being asked.
+> **구현 예정** — 자율 모니터링 모드는 아직 구현되지 않았습니다.
+
+qracer runs autonomously during market hours — monitoring watchlists, detecting significant events, and proactively alerting users without being asked.
 
 Users don't configure modes. The agent decides when to act.
 

--- a/docs/conversational-layer.md
+++ b/docs/conversational-layer.md
@@ -60,7 +60,9 @@ Resolution rules:
 
 ## Proactive Alerts
 
-During market hours, Tracer monitors for events relevant to the conversation context and pushes alerts:
+> **구현 예정** — 현재는 사용자 쿼리에 대한 응답만 지원합니다. 실시간 모니터링 및 자동 알림은 아직 구현되지 않았습니다.
+
+During market hours, qracer monitors for events relevant to the conversation context and pushes alerts:
 
 ### Alert Types
 
@@ -184,5 +186,5 @@ class ToolResult:
 | ≥2 tools fail in Research mode | Exit early; list missing data |
 | LLM call fails | Retry once; partial result if still failing |
 | Rate limit mid-query | Serve from cache if available |
-| WebSocket disconnect | Fall back to REST polling; note in session |
+| WebSocket disconnect (구현 예정) | Fall back to REST polling; note in session |
 | Alert flood | Rate-limit to 1 per ticker per 5 min |

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -17,19 +17,25 @@ Complete audit trail — reconstructs exactly what the agent did and why.
 
 ## Tier 2 — Compressed Summary (Markdown)
 
+> **구현 예정** — 현재 SessionCompactor가 존재하지만 요약이 파일로 저장되지 않습니다.
+
 When a session exceeds 8,000 tokens (measured via `tiktoken`), SessionManager compacts the conversation into a Markdown summary using the reporter role (Haiku). The summary replaces raw turns in the active context window; the JSONL is preserved.
 
 ## Tier 3 — Search Index (DuckDB)
 
+> **구현 예정** — 현재 MemorySearcher가 DuckDB FTS로 키워드 검색을 지원하지만, 벡터 임베딩(HNSW) 검색은 미구현입니다.
+
 DuckDB indexes all Tier 2 Markdown summaries for hybrid retrieval: keyword (FTS) + vector similarity (VSS/HNSW). Writes occur only at compaction time.
 
-- Embedding model: `text-embedding-3-small` (OpenAI API) or `all-MiniLM-L6-v2` (local fallback). Configured in `TOOLS.md`.
+- Embedding model: `text-embedding-3-small` (OpenAI API) or `all-MiniLM-L6-v2` (local fallback).
 - Tables: `session_index` (FTS), `session_embeddings` (HNSW).
 - Source of truth is the Markdown files; DuckDB is the index only.
 
 The agent calls `memory_search` autonomously when past context may be relevant.
 
 ## MEMORY.md vs. Tier 2
+
+> **구현 예정** — MEMORY.md, BOOTSTRAP.md 기반 크로스 세션 메모리는 아직 구현되지 않았습니다.
 
 - **Tier 2**: auto-generated, per-session. Temporary working memory.
 - **MEMORY.md**: cross-session long-term memory. Manually curated or auto-aggregated. Contains active theses and strong multi-session signals. Loaded at session start via `BOOTSTRAP.md`.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,6 +1,6 @@
 # Pipeline
 
-Tracer has two pipelines. The IntentRouter selects which one handles each query.
+qracer has two pipelines. The IntentRouter selects which one handles each query.
 
 ## LivePipeline (QuickPath)
 
@@ -77,13 +77,13 @@ Screening → Macro Regime → Cross-Market Discovery → Consensus Mapping
 - Output: ranked list with risk assessment
 - Agent: **strategist**
 
-### Step 7: Trade Thesis Generation (planned)
+### Step 7: Trade Thesis Generation
 - Convert analysis into structured, actionable output
 - Output fields: entry zone, target price, stop-loss, risk/reward ratio, catalyst + date, conviction (1-10)
 - Conviction score drives position sizing suggestion
 - Agent: **strategist**
 
-### Step 8: Risk Check (planned)
+### Step 8: Risk Check
 - Consult risk module (see [risk-system.md](risk-system.md)) before finalizing recommendation
 - Check portfolio exposure: sector concentration, correlation to existing holdings, beta impact
 - Adjust position sizing based on current portfolio state
@@ -113,7 +113,7 @@ ResearchPipeline runs when **any** of these are true:
 | `/deep` command | `/deep AAPL` |
 | `deep_dive` intent | "Give me everything on Samsung" |
 | `alpha_hunt` intent | "Where's the hidden alpha right now?" |
-| Scheduled | Nightly batch run (if configured) |
+| Scheduled (구현 예정) | Nightly batch run |
 
 Everything else goes through LivePipeline.
 

--- a/docs/user-experience.md
+++ b/docs/user-experience.md
@@ -76,6 +76,9 @@ Agent: "AAPL, right? Analysis from buy perspective?"
 ### 3.1 Technical Implementation
 
 **Memory Structure**
+
+> **구현 예정** — 현재는 인메모리 ConversationContext로 동작합니다.
+
 ```text
 Session Memory (Redis/SQLite)
 ├── session_id: uuid
@@ -279,6 +282,8 @@ System management commands only. Investment analysis via natural language.
 
 ## 5. Dashboard
 
+> **구현 예정** — 현재는 CLI REPL 인터페이스로 동작합니다.
+
 qracer main interface. Left sidebar menu + right info panel structure.
 
 ### Layout
@@ -414,23 +419,27 @@ After install, run `qracer install` for initial setup:
 ```text
 $ qracer install
 
-🎯 Starting qracer installation.
+Setting up qracer config in ~/.qracer
 
-1. Create config directory
-   Creating ~/.qracer/... [OK]
+  Created config.toml
+  Created providers.toml
+  Created portfolio.toml
 
-2. Data source setup
-   Enter Finnhub API key (optional): 
-   Enter FRED API key (optional):
+  Select LLM provider:
+    1. Claude (Anthropic)
+    2. OpenAI (GPT-4o)
+    3. Gemini (Google)
+  Choice [1]: 1
 
-3. Telegram notification setup (optional)
-   Bot Token: 
-   Chat ID:
+  ANTHROPIC_API_KEY: sk-ant-xxx...
 
-4. Portfolio initial setup
-   Base currency (USD/KRW): USD
+  Portfolio currency [USD]: USD
 
-✅ Install complete! Check commands with 'qracer --help'.
+✓ Setup complete! Claude (Anthropic) enabled as LLM provider.
+
+Next steps:
+  qracer status   — check configuration
+  qracer repl     — start interactive session
 ```
 
 ### Post-Install First Run


### PR DESCRIPTION
## Summary
- **"Tracer" → "qracer"** 전체 docs에서 옛 이름 수정 (architecture, pipeline, conversational-layer, autonomous-mode)
- **"tracer.db" → "qracer.db"** 데이터베이스 파일명 수정
- **미구현 기능에 "구현 예정" 표기** 추가 (Plugin system, WebSocket, Dashboard, Memory Tier 2/3, Autonomous mode, Proactive alerts)
- **이미 구현된 Step 7/8에서 "(planned)" 제거**
- **install 위저드 문서 업데이트** — LLM 선택 메뉴 반영

## Test plan
- [x] docs 내 "Tracer" grep → 0건
- [x] docs 내 "tracer.db" grep → 0건
- [x] 코드 변경 없음 — 테스트 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)