### PR TITLE
fix: remove silent failures across the pipeline

### DIFF
--- a/src/qracer/cli.py
+++ b/src/qracer/cli.py
@@ -266,7 +266,12 @@ def _write_toml(path: Path, data: dict) -> None:  # type: ignore[type-arg]
 
 
 def _build_registries() -> tuple:  # type: ignore[type-arg]
-    """Build LLM and data registries from providers.toml + provider catalog."""
+    """Build LLM and data registries from providers.toml + provider catalog.
+
+    Returns ``(llm_registry, data_registry, warnings)`` where *warnings*
+    is a list of human-readable strings describing providers that could
+    not be loaded.
+    """
     import importlib
 
     from qracer.data.registry import DataRegistry
@@ -277,6 +282,7 @@ def _build_registries() -> tuple:  # type: ignore[type-arg]
     config = load_config()
     llm_registry = LLMRegistry()
     data_registry = DataRegistry()
+    warnings: list[str] = []
 
     sorted_providers = sorted(
         config.providers.providers.items(),
@@ -287,44 +293,48 @@ def _build_registries() -> tuple:  # type: ignore[type-arg]
         if not prov_cfg.enabled:
             continue
 
+        # Resolve API key (shared by data and llm paths)
+        api_key: str | None = None
+        if prov_cfg.api_key_env:
+            api_key = config.credentials.get(prov_cfg.api_key_env) or os.environ.get(
+                prov_cfg.api_key_env
+            )
+            if not api_key:
+                msg = f"{name}: {prov_cfg.api_key_env} not set — skipped"
+                warnings.append(msg)
+                logger.warning("Provider '%s' skipped: %s not set", name, prov_cfg.api_key_env)
+                continue
+
         if prov_cfg.kind == "data" and name in BUILTIN_DATA_PROVIDERS:
             adapter_path, cap_paths = BUILTIN_DATA_PROVIDERS[name]
             try:
                 mod_path, cls_name = adapter_path.rsplit(".", 1)
                 adapter_cls = getattr(importlib.import_module(mod_path), cls_name)
-                # Inject API key from credentials if declared
-                api_key = None
-                if prov_cfg.api_key_env:
-                    api_key = config.credentials.get(prov_cfg.api_key_env) or os.environ.get(
-                        prov_cfg.api_key_env
-                    )
                 adapter = adapter_cls(api_key=api_key) if api_key else adapter_cls()
                 caps = []
                 for cp in cap_paths:
                     cp_mod, cp_name = cp.rsplit(".", 1)
                     caps.append(getattr(importlib.import_module(cp_mod), cp_name))
                 data_registry.register(name, adapter, caps)
-            except Exception:
-                logger.warning("Data provider '%s' unavailable", name, exc_info=True)
+            except Exception as exc:
+                msg = f"{name}: {exc}"
+                warnings.append(msg)
+                logger.warning("Data provider '%s' unavailable: %s", name, exc)
 
         elif prov_cfg.kind == "llm" and name in BUILTIN_LLM_PROVIDERS:
             adapter_path, role_values = BUILTIN_LLM_PROVIDERS[name]
             try:
                 mod_path, cls_name = adapter_path.rsplit(".", 1)
                 adapter_cls = getattr(importlib.import_module(mod_path), cls_name)
-                # Inject API key from credentials if declared
-                api_key = None
-                if prov_cfg.api_key_env:
-                    api_key = config.credentials.get(prov_cfg.api_key_env) or os.environ.get(
-                        prov_cfg.api_key_env
-                    )
                 adapter = adapter_cls(api_key=api_key)
                 roles = [Role(v) for v in role_values]
                 llm_registry.register(name, adapter, roles)
-            except Exception:
-                logger.warning("LLM provider '%s' unavailable", name, exc_info=True)
+            except Exception as exc:
+                msg = f"{name}: {exc}"
+                warnings.append(msg)
+                logger.warning("LLM provider '%s' unavailable: %s", name, exc)
 
-    return llm_registry, data_registry
+    return llm_registry, data_registry, warnings
 
 
 _HELP_TEXT = """\
@@ -376,9 +386,12 @@ async def _repl_loop(engine: object, watchlist: object) -> None:
         # Hot-plug: reload config and rebuild registries if files changed
         if has_config_changed():
             try:
-                llm_reg, data_reg = _build_registries()
+                llm_reg, data_reg, reload_warnings = _build_registries()
                 engine.update_registries(llm_reg, data_reg)  # type: ignore[attr-defined]
-                click.echo("⟳ Configuration reloaded.\n")
+                click.echo("⟳ Configuration reloaded.")
+                for warn in reload_warnings:
+                    click.echo(f"  ⚠ {warn}")
+                click.echo()
             except Exception:
                 logger.warning("Config reload failed", exc_info=True)
 
@@ -467,7 +480,13 @@ def repl() -> None:
     from qracer.memory.session_logger import SessionLogger
     from qracer.watchlist import Watchlist
 
-    llm_registry, data_registry = _build_registries()
+    llm_registry, data_registry, provider_warnings = _build_registries()
+
+    # Surface provider warnings so the user knows what's unavailable.
+    for warn in provider_warnings:
+        click.echo(f"  ⚠ {warn}")
+    if provider_warnings:
+        click.echo()
 
     # Create session logger in ~/.qracer/sessions/<uuid>.jsonl
     sessions_dir = _user_dir() / "sessions"

--- a/src/qracer/config/loader.py
+++ b/src/qracer/config/loader.py
@@ -92,14 +92,24 @@ def resolve_config_dirs() -> list[Path]:
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
-    """Read a TOML file, returning an empty dict on failure."""
+    """Read a TOML file, returning an empty dict if not found.
+
+    Raises a clear warning with the file path and error detail on parse
+    failures so the user can fix the file rather than getting silently
+    empty config.
+    """
     try:
         with open(path, "rb") as f:
             return tomllib.load(f)
     except FileNotFoundError:
         return {}
     except Exception:
-        logger.warning("Failed to parse %s", path, exc_info=True)
+        logger.error(
+            "Failed to parse %s — config from this file will be ignored. "
+            "Fix the file or delete it and re-run 'qracer install'.",
+            path,
+            exc_info=True,
+        )
         return {}
 
 

--- a/src/qracer/conversation/analysis_loop.py
+++ b/src/qracer/conversation/analysis_loop.py
@@ -30,6 +30,9 @@ class AnalysisResult:
     trade_thesis: TradeThesis | None = None
 
 
+_MAX_CONSECUTIVE_EVAL_FAILURES = 2
+
+
 class AnalysisLoop:
     """Iteratively gathers data until confidence threshold or max iterations.
 
@@ -56,6 +59,7 @@ class AnalysisLoop:
         """Run the analysis loop starting from initial tool results."""
         all_results = list(initial_results)
         iterations = 0
+        consecutive_eval_failures = 0
 
         for iteration in range(self._max_iterations):
             iterations = iteration + 1
@@ -71,7 +75,23 @@ class AnalysisLoop:
                     early_exit_reason=">=2 tools failed in first iteration",
                 )
 
-            confidence, missing_tools = await self._evaluate(intent, successful)
+            confidence, missing_tools, eval_ok = await self._evaluate(intent, successful)
+
+            if not eval_ok:
+                consecutive_eval_failures += 1
+                if consecutive_eval_failures >= _MAX_CONSECUTIVE_EVAL_FAILURES:
+                    logger.error(
+                        "AnalysisLoop: %d consecutive evaluation failures, exiting early",
+                        consecutive_eval_failures,
+                    )
+                    return AnalysisResult(
+                        results=all_results,
+                        confidence=confidence,
+                        iterations=iterations,
+                        early_exit_reason="LLM evaluation failed repeatedly",
+                    )
+            else:
+                consecutive_eval_failures = 0
 
             if confidence >= self._confidence_threshold:
                 return AnalysisResult(
@@ -99,8 +119,15 @@ class AnalysisLoop:
             iterations=iterations,
         )
 
-    async def _evaluate(self, intent: Intent, results: list[ToolResult]) -> tuple[float, list[str]]:
-        """Ask the analyst LLM to evaluate confidence and suggest missing tools."""
+    async def _evaluate(
+        self, intent: Intent, results: list[ToolResult]
+    ) -> tuple[float, list[str], bool]:
+        """Ask the analyst LLM to evaluate confidence and suggest missing tools.
+
+        Returns ``(confidence, missing_tools, success)``.  When the LLM
+        call fails, *success* is ``False`` so the caller can track
+        consecutive failures and abort early.
+        """
         evidence = format_evidence(results)
         system = (
             "You are an analyst evaluating whether collected data is sufficient to "
@@ -132,10 +159,10 @@ class AnalysisLoop:
             missing = [t for t in parsed.get("missing_tools", []) if t in TOOL_DISPATCH]
             already_called = {r.tool for r in results}
             missing = [t for t in missing if t not in already_called]
-            return confidence, missing
+            return confidence, missing, True
         except Exception:
             logger.warning("AnalysisLoop evaluation failed", exc_info=True)
-            return 0.0, []
+            return 0.0, [], False
 
 
 def format_evidence(results: list[ToolResult]) -> str:

--- a/src/qracer/conversation/engine.py
+++ b/src/qracer/conversation/engine.py
@@ -353,6 +353,12 @@ class ConversationEngine:
                     )
                 except (KeyError, ValueError, TypeError):
                     logger.warning("Failed to reconstruct TradeThesis from result")
+            elif not thesis_result.success:
+                logger.warning(
+                    "Trade thesis generation failed for %s: %s",
+                    intent.tickers[0],
+                    thesis_result.error,
+                )
 
         # Risk check (step 8) — only when a trade thesis was produced.
         if analysis.trade_thesis is not None and self._portfolio_config.holdings:

--- a/src/qracer/risk/correlation.py
+++ b/src/qracer/risk/correlation.py
@@ -211,7 +211,12 @@ class CorrelationEngine:
 
             benchmark_bars = await self._provider.get_ohlcv(BENCHMARK_TICKER, start, end)
         except Exception:
-            logger.warning("Failed to fetch OHLCV data for correlation computation", exc_info=True)
+            logger.warning(
+                "Correlation/beta unavailable: failed to fetch OHLCV data for %s. "
+                "Risk assessment will proceed without correlation adjustments.",
+                [h.ticker for h in holdings],
+                exc_info=True,
+            )
             return None
 
         result = compute_correlation_result(holdings, ohlcv_data, benchmark_bars)

--- a/src/qracer/tools/pipeline.py
+++ b/src/qracer/tools/pipeline.py
@@ -388,6 +388,16 @@ async def risk_check(
         # Check limits (including the hypothetical new position).
         breached = calculator.check_limits(snapshot, exposure)
 
+        # Flag missing data so the report can mention it.
+        caveats: list[str] = []
+        missing_prices = [h.ticker for h in config.holdings if h.ticker not in prices]
+        if missing_prices:
+            caveats.append(f"Price unavailable for: {', '.join(missing_prices)}")
+        if exposure.portfolio_beta == 0.0 and len(snapshot.holdings) > 0:
+            caveats.append(
+                "Correlation/beta data unavailable — sizing without correlation adjustment"
+            )
+
         now = datetime.now()
         return ToolResult(
             tool="risk_check",
@@ -401,6 +411,7 @@ async def risk_check(
                 "top_sector": exposure.top_sector,
                 "top_sector_pct": exposure.top_sector_pct,
                 "limits_breached": breached,
+                "caveats": caveats,
                 "sized_recommendation": (
                     f"Allocate {allocation_pct:.2f}% of portfolio to {ticker}"
                     if not breached

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,8 @@ from qracer.cli import _build_registries
 
 class TestBuildRegistries:
     def test_returns_registry_tuple(self) -> None:
-        """Should return (LLMRegistry, DataRegistry) without crashing."""
-        llm, data = _build_registries()
+        """Should return (LLMRegistry, DataRegistry, warnings) without crashing."""
+        llm, data, warnings = _build_registries()
         assert llm is not None
         assert data is not None
+        assert isinstance(warnings, list)


### PR DESCRIPTION
## Summary
6개 silent failure 포인트를 명시적 에러 처리로 교체합니다.

Closes #96, #97, #98, #99, #100, #101

| Issue | 변경 | Before → After |
|:---:|------|------|
| #98 | Config TOML 파싱 | 빈 dict 반환 → `logger.error` + 파일 경로/가이드 |
| #101 | API 키 검증 | None으로 인스턴스화 → 키 없으면 등록 스킵 |
| #99 | Provider 실패 알림 | 로그만 → REPL 시작 시 `⚠ provider: reason` 표시 |
| #96 | AnalysisLoop 평가 | `(0.0, [])` 반환 → 연속 2회 실패 시 조기 종료 |
| #97 | Correlation 엔진 | `None` 반환 → risk_check에 caveats 필드 추가 |
| #100 | Trade thesis | silent skip → 실패 사유 로깅 |

## Design
- `_build_registries()`가 `(llm, data, warnings)` 3-tuple 반환
- REPL 시작 시 + hot-reload 시 warnings를 유저에게 표시
- AnalysisLoop._evaluate()가 `(confidence, tools, success)` 3-tuple 반환
- risk_check ToolResult에 `caveats` 필드 추가 (누락 데이터 명시)

## Test plan
- [x] 기존 테스트 통과 (399 passed)
- [x] ruff lint + format 통과
- [x] test_cli.py 업데이트 (_build_registries 3-tuple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)