### PR TITLE
refactor: core design cleanup — dead code, tool validation, dynamic sectors

### DIFF
--- a/src/qracer/conversation/dispatcher.py
+++ b/src/qracer/conversation/dispatcher.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from qracer.conversation.intent import Intent
+from qracer.conversation.intent import INTENT_TOOL_MAP, Intent
 from qracer.data.registry import DataRegistry
 from qracer.models import ToolResult
 from qracer.tools import pipeline
@@ -20,6 +20,15 @@ TOOL_DISPATCH: dict[str, str] = {
     "cross_market": "tickers",
     "memory_search": "query",
 }
+
+# Validate that all tools referenced in INTENT_TOOL_MAP exist in TOOL_DISPATCH.
+# This catches sync errors at import time rather than at runtime.
+_all_intent_tools = {t for tools in INTENT_TOOL_MAP.values() for t in tools}
+_unknown_tools = _all_intent_tools - set(TOOL_DISPATCH)
+if _unknown_tools:
+    raise RuntimeError(
+        f"INTENT_TOOL_MAP references unknown tools not in TOOL_DISPATCH: {_unknown_tools}"
+    )
 
 
 async def invoke_tool(

--- a/src/qracer/conversation/engine.py
+++ b/src/qracer/conversation/engine.py
@@ -31,7 +31,7 @@ from qracer.conversation.quickpath import format_portfolio, format_quickpath
 from qracer.conversation.report_exporter import ReportExporter
 from qracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 from qracer.data.providers import PriceProvider
-from qracer.data.registry import DataRegistry, build_registry
+from qracer.data.registry import DataRegistry
 from qracer.llm.registry import LLMRegistry
 from qracer.memory.session_compactor import SessionCompactor
 from qracer.memory.session_logger import SessionLogger, TurnRecord
@@ -61,7 +61,7 @@ class ConversationEngine:
     def __init__(
         self,
         llm_registry: LLMRegistry,
-        data_registry: DataRegistry | None = None,
+        data_registry: DataRegistry,
         portfolio_config: PortfolioConfig | None = None,
         *,
         max_iterations: int = MAX_ITERATIONS,
@@ -70,8 +70,6 @@ class ConversationEngine:
         report_dir: Path | None = None,
         memory_searcher: object | None = None,
     ) -> None:
-        if data_registry is None:
-            data_registry = build_registry()
         self._llm = llm_registry
         self._intent_parser = IntentParser(llm_registry)
         self._analysis_loop = AnalysisLoop(

--- a/src/qracer/data/__init__.py
+++ b/src/qracer/data/__init__.py
@@ -10,7 +10,7 @@ from qracer.data.providers import (
     NewsProvider,
     PriceProvider,
 )
-from qracer.data.registry import DataRegistry, build_registry
+from qracer.data.registry import DataRegistry
 from qracer.data.yfinance_adapter import YfinanceAdapter
 
 __all__ = [
@@ -18,7 +18,6 @@ __all__ = [
     "AlternativeProvider",
     "AlternativeRecord",
     "DataRegistry",
-    "build_registry",
     "FundamentalData",
     "FundamentalProvider",
     "MacroIndicator",

--- a/src/qracer/data/registry.py
+++ b/src/qracer/data/registry.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from qracer.provider_catalog import BUILTIN_DATA_PROVIDERS
-
 # Provider protocol classes are used as capability keys (e.g. PriceProvider, NewsProvider).
 # pyright doesn't support type[Protocol], so we use type[Any] as the capability type.
 ProviderType = type[Any]
@@ -159,61 +157,3 @@ class DataRegistry:
     def capabilities(self) -> list[ProviderType]:
         """List all registered capabilities."""
         return list(self._adapters.keys())
-
-
-def _load_config_lazy() -> Any:
-    """Lazy import of load_config to avoid circular imports at module level."""
-    from qracer.config.loader import load_config
-
-    return load_config()
-
-
-def build_registry() -> DataRegistry:
-    """Build a DataRegistry from providers.toml configuration.
-
-    Reads the providers config, instantiates each enabled built-in adapter,
-    and registers it with its capabilities.  Providers are registered in
-    priority order (lower number = higher priority).
-    """
-    import importlib
-
-    config = _load_config_lazy()
-    registry = DataRegistry()
-
-    # Sort providers by priority (lower = higher priority)
-    sorted_providers = sorted(
-        config.providers.providers.items(),
-        key=lambda item: item[1].priority,
-    )
-
-    for name, prov_cfg in sorted_providers:
-        if not prov_cfg.enabled:
-            logger.debug("Skipping disabled provider: %s", name)
-            continue
-
-        if name not in BUILTIN_DATA_PROVIDERS:
-            logger.warning("Unknown provider '%s' in config, skipping", name)
-            continue
-
-        adapter_path, cap_paths = BUILTIN_DATA_PROVIDERS[name]
-
-        try:
-            # Import adapter class
-            module_path, class_name = adapter_path.rsplit(".", 1)
-            module = importlib.import_module(module_path)
-            adapter_cls = getattr(module, class_name)
-            adapter = adapter_cls()
-
-            # Import capability classes
-            caps: list[ProviderType] = []
-            for cap_path in cap_paths:
-                cap_mod_path, cap_name = cap_path.rsplit(".", 1)
-                cap_mod = importlib.import_module(cap_mod_path)
-                caps.append(getattr(cap_mod, cap_name))
-
-            registry.register(name, adapter, caps)
-            logger.info("Registered provider: %s", name)
-        except Exception:
-            logger.warning("Failed to instantiate provider '%s'", name, exc_info=True)
-
-    return registry

--- a/src/qracer/risk/calculator.py
+++ b/src/qracer/risk/calculator.py
@@ -203,24 +203,42 @@ class RiskCalculator:
         )
 
     async def build_exposure_async(self, snapshot: PortfolioSnapshot) -> ExposureBreakdown:
-        """Build exposure breakdown with correlation/beta computed asynchronously."""
-        base = self.build_exposure(snapshot)
+        """Build exposure breakdown with async sector lookup and correlation/beta."""
+        # Async sector lookup via FundamentalProvider (falls back to hardcoded).
+        sector_values: dict[str, float] = {}
+        for h in snapshot.holdings:
+            sector = await self._sectors.get_sector_async(h.ticker)
+            sector_values[sector] = sector_values.get(sector, 0.0) + h.market_value
 
-        if self._correlation_engine is None or not snapshot.holdings:
-            return base
+        total = snapshot.total_value
+        sector_weights: dict[str, float] = {}
+        for sector, value in sector_values.items():
+            sector_weights[sector] = round(value / total * 100.0, 2) if total > 0 else 0.0
 
-        corr_result = await self._correlation_engine.compute(snapshot.holdings)
-        if corr_result is None:
-            return base
+        if sector_weights:
+            top_sector = max(sector_weights, key=lambda s: sector_weights[s])
+            top_sector_pct = sector_weights[top_sector]
+        else:
+            top_sector = "N/A"
+            top_sector_pct = 0.0
 
-        self._last_correlation = corr_result
+        # Correlation/beta computation.
+        portfolio_beta: float | None = None
+        correlation_avg: float | None = None
+
+        if self._correlation_engine is not None and snapshot.holdings:
+            corr_result = await self._correlation_engine.compute(snapshot.holdings)
+            if corr_result is not None:
+                self._last_correlation = corr_result
+                portfolio_beta = corr_result.portfolio_beta
+                correlation_avg = corr_result.correlation_avg
 
         return ExposureBreakdown(
-            sector_weights=base.sector_weights,
-            top_sector=base.top_sector,
-            top_sector_pct=base.top_sector_pct,
-            portfolio_beta=corr_result.portfolio_beta,
-            correlation_avg=corr_result.correlation_avg,
+            sector_weights=sector_weights,
+            top_sector=top_sector,
+            top_sector_pct=top_sector_pct,
+            portfolio_beta=portfolio_beta,
+            correlation_avg=correlation_avg,
         )
 
     def check_limits(self, snapshot: PortfolioSnapshot, exposure: ExposureBreakdown) -> list[str]:

--- a/src/qracer/tools/pipeline.py
+++ b/src/qracer/tools/pipeline.py
@@ -364,10 +364,11 @@ async def risk_check(
     Builds a portfolio snapshot from current prices, sizes the proposed
     position using conviction from the thesis, and checks portfolio limits.
     """
-    from qracer.risk.calculator import RiskCalculator
+    from qracer.risk.calculator import RiskCalculator, SectorResolver
 
     try:
-        calculator = RiskCalculator(config)
+        sector_resolver = SectorResolver(data_registry=registry)
+        calculator = RiskCalculator(config, sector_resolver=sector_resolver)
 
         # Gather current prices for all holdings.
         prices: dict[str, float] = {}
@@ -380,7 +381,7 @@ async def risk_check(
                 logger.warning("Could not fetch price for %s: %s", holding.ticker, exc)
 
         snapshot = calculator.build_snapshot(prices)
-        exposure = calculator.build_exposure(snapshot)
+        exposure = await calculator.build_exposure_async(snapshot)
 
         # Size the proposed position.
         allocation_pct = calculator.size_position(ticker, thesis.conviction, snapshot)

--- a/tests/data/test_registry.py
+++ b/tests/data/test_registry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import date
-from unittest.mock import patch
 
 import pytest
 
@@ -15,7 +14,6 @@ from qracer.data.providers import (
     MacroIndicator,
     MacroProvider,
 )
-from qracer.data.registry import build_registry as _build_registry
 
 
 class FakePriceAdapter:
@@ -240,75 +238,3 @@ class TestGetWithFallback:
         registry.register("kw", KwargAdapter(), [PriceProvider])
         result = registry.get_with_fallback(PriceProvider, "fetch", "AAPL", period="5d")
         assert result == "AAPL-5d"
-
-
-def _make_provider_cfg(enabled: bool = True, priority: int = 100, tier: str = "warm") -> object:
-    """Create a mock ProviderConfig without importing tracer.config."""
-    from types import SimpleNamespace
-
-    return SimpleNamespace(enabled=enabled, priority=priority, tier=tier, api_key_env=None)
-
-
-def _make_config(providers: dict | None = None) -> object:
-    """Create a mock QracerConfig without importing tracer.config."""
-    from types import SimpleNamespace
-
-    prov_ns = SimpleNamespace(providers=providers or {})
-    return SimpleNamespace(providers=prov_ns)
-
-
-class TestBuildRegistry:
-    def test_build_with_yfinance_enabled(self) -> None:
-        """build_registry loads yfinance when config says enabled."""
-        mock_config = _make_config(
-            {"yfinance": _make_provider_cfg(enabled=True, priority=100, tier="hot")}
-        )
-
-        with patch("qracer.data.registry._load_config_lazy", return_value=mock_config):
-            registry = _build_registry()
-
-        # YfinanceAdapter should be registered for PriceProvider
-        adapters = registry.get_all(PriceProvider)
-        assert len(adapters) == 1
-        assert adapters[0][0] == "yfinance"
-
-    def test_build_with_disabled_provider(self) -> None:
-        """Disabled providers are not registered."""
-        mock_config = _make_config(
-            {"yfinance": _make_provider_cfg(enabled=False, priority=100, tier="hot")}
-        )
-
-        with patch("qracer.data.registry._load_config_lazy", return_value=mock_config):
-            registry = _build_registry()
-
-        assert registry.get_all(PriceProvider) == []
-
-    def test_build_with_unknown_provider(self) -> None:
-        """Unknown provider names are skipped without error."""
-        mock_config = _make_config(
-            {"unknown_source": _make_provider_cfg(enabled=True, priority=50)}
-        )
-
-        with patch("qracer.data.registry._load_config_lazy", return_value=mock_config):
-            registry = _build_registry()
-
-        assert registry.capabilities() == []
-
-    def test_build_empty_config(self) -> None:
-        """Empty providers config returns empty registry."""
-        with patch("qracer.data.registry._load_config_lazy", return_value=_make_config()):
-            registry = _build_registry()
-
-        assert registry.capabilities() == []
-
-    def test_build_priority_order(self) -> None:
-        """Providers are registered in priority order (lower number first)."""
-        mock_config = _make_config(
-            {"yfinance": _make_provider_cfg(enabled=True, priority=50, tier="warm")}
-        )
-
-        with patch("qracer.data.registry._load_config_lazy", return_value=mock_config):
-            registry = _build_registry()
-
-        adapters = registry.get_all(PriceProvider)
-        assert len(adapters) == 1


### PR DESCRIPTION
## Summary
아키텍처 리뷰에서 나온 3가지 설계 수준 이슈 정리.

### 1. Dead `build_registry()` 제거 (-109 lines)
- `data/registry.py`의 `build_registry()` + `_load_config_lazy()` 삭제
- `cli._build_registries()`가 유일한 레지스트리 빌더로 통합
- `ConversationEngine.data_registry`를 필수 파라미터로 변경

### 2. INTENT_TOOL_MAP ↔ TOOL_DISPATCH 동기화 검증
- `dispatcher.py` 모듈 로드 시 자동 검증
- 잘못된 tool 이름이 있으면 import 시점에 `RuntimeError`

### 3. 동적 섹터 조회 활성화
- `build_exposure_async()`가 `get_sector_async()` 호출 → FundamentalProvider 시도
- `risk_check`에서 `SectorResolver(data_registry=registry)` 주입
- 하드코딩 `_TICKER_SECTOR`는 fallback으로만 사용

## Impact
```
Before: 레지스트리 빌더 2개 중복, tool 맵 동기화 안됨, 섹터 항상 하드코딩
After:  빌더 1개, import 시 검증, Finnhub에서 실시간 섹터 조회
```

## Test plan
- [x] 394 passed (기존 3 failures는 환경 이슈)
- [x] ruff lint + format 통과
- [x] `build_registry` grep → src에서 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)