### PR TITLE
fix: add explicit correlation_data_unavailable flag to risk models (closes #97)

### DIFF
--- a/src/qracer/risk/calculator.py
+++ b/src/qracer/risk/calculator.py
@@ -225,6 +225,7 @@ class RiskCalculator:
         # Correlation/beta computation.
         portfolio_beta: float | None = None
         correlation_avg: float | None = None
+        correlation_data_unavailable = False
 
         if self._correlation_engine is not None and snapshot.holdings:
             corr_result = await self._correlation_engine.compute(snapshot.holdings)
@@ -232,6 +233,8 @@ class RiskCalculator:
                 self._last_correlation = corr_result
                 portfolio_beta = corr_result.portfolio_beta
                 correlation_avg = corr_result.correlation_avg
+            else:
+                correlation_data_unavailable = True
 
         return ExposureBreakdown(
             sector_weights=sector_weights,
@@ -239,6 +242,7 @@ class RiskCalculator:
             top_sector_pct=top_sector_pct,
             portfolio_beta=portfolio_beta,
             correlation_avg=correlation_avg,
+            correlation_data_unavailable=correlation_data_unavailable,
         )
 
     def check_limits(self, snapshot: PortfolioSnapshot, exposure: ExposureBreakdown) -> list[str]:
@@ -358,10 +362,18 @@ class RiskCalculator:
         alert_threshold = self._config.limits.max_drawdown_alert_pct
         drawdown_alert = drawdown_pct > alert_threshold
 
+        warnings: list[str] = []
+        if exposure.correlation_data_unavailable:
+            warnings.append(
+                "Correlation/beta data unavailable — risk assessment "
+                "proceeded without correlation adjustments"
+            )
+
         return RiskAssessment(
             snapshot=snapshot,
             exposure=exposure,
             limits_breached=breached,
+            warnings=warnings,
             max_drawdown_alert=drawdown_alert,
             current_drawdown_pct=round(drawdown_pct, 2),
             peak_value=round(self._peak_value, 2),

--- a/src/qracer/risk/models.py
+++ b/src/qracer/risk/models.py
@@ -43,6 +43,7 @@ class ExposureBreakdown(BaseModel):
     top_sector_pct: float
     portfolio_beta: float | None = None
     correlation_avg: float | None = None
+    correlation_data_unavailable: bool = False
 
 
 class RiskAssessment(BaseModel):
@@ -51,6 +52,7 @@ class RiskAssessment(BaseModel):
     snapshot: PortfolioSnapshot
     exposure: ExposureBreakdown
     limits_breached: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
     max_drawdown_alert: bool = False
     current_drawdown_pct: float = 0.0
     peak_value: float = 0.0

--- a/src/qracer/tools/pipeline.py
+++ b/src/qracer/tools/pipeline.py
@@ -394,7 +394,7 @@ async def risk_check(
         missing_prices = [h.ticker for h in config.holdings if h.ticker not in prices]
         if missing_prices:
             caveats.append(f"Price unavailable for: {', '.join(missing_prices)}")
-        if exposure.portfolio_beta == 0.0 and len(snapshot.holdings) > 0:
+        if exposure.correlation_data_unavailable:
             caveats.append(
                 "Correlation/beta data unavailable — sizing without correlation adjustment"
             )

--- a/tests/risk/test_correlation.py
+++ b/tests/risk/test_correlation.py
@@ -428,6 +428,92 @@ class TestRiskCalculatorCorrelationIntegration:
         assert pct == 3.0
 
     @pytest.mark.asyncio
+    async def test_build_exposure_async_sets_flag_on_failure(self) -> None:
+        from qracer.config.models import Holding, PortfolioConfig, PortfolioLimits
+        from qracer.risk.calculator import RiskCalculator
+
+        provider = AsyncMock()
+        provider.get_ohlcv = AsyncMock(side_effect=RuntimeError("network error"))
+
+        engine = CorrelationEngine(price_provider=provider)
+        config = PortfolioConfig(
+            currency="USD",
+            holdings=[Holding(ticker="AAPL", shares=100, avg_cost=150.0)],
+            limits=PortfolioLimits(),
+        )
+        calc = RiskCalculator(config, correlation_engine=engine)
+        snapshot = calc.build_snapshot({"AAPL": 180.0})
+        exposure = await calc.build_exposure_async(snapshot)
+
+        assert exposure.correlation_data_unavailable is True
+        assert exposure.portfolio_beta is None
+        assert exposure.correlation_avg is None
+
+    @pytest.mark.asyncio
+    async def test_build_exposure_async_flag_false_on_success(self) -> None:
+        from qracer.config.models import Holding, PortfolioConfig, PortfolioLimits
+        from qracer.risk.calculator import RiskCalculator
+
+        provider = AsyncMock()
+        closes = [100.0, 101.0, 102.0, 101.5, 103.0, 104.0, 103.5]
+        provider.get_ohlcv = AsyncMock(return_value=_make_bars(closes))
+
+        engine = CorrelationEngine(price_provider=provider)
+        config = PortfolioConfig(
+            currency="USD",
+            holdings=[Holding(ticker="AAPL", shares=100, avg_cost=150.0)],
+            limits=PortfolioLimits(),
+        )
+        calc = RiskCalculator(config, correlation_engine=engine)
+        snapshot = calc.build_snapshot({"AAPL": 180.0})
+        exposure = await calc.build_exposure_async(snapshot)
+
+        assert exposure.correlation_data_unavailable is False
+        assert exposure.portfolio_beta is not None
+
+    @pytest.mark.asyncio
+    async def test_assess_async_populates_warnings_on_failure(self) -> None:
+        from qracer.config.models import Holding, PortfolioConfig, PortfolioLimits
+        from qracer.risk.calculator import RiskCalculator
+
+        provider = AsyncMock()
+        provider.get_ohlcv = AsyncMock(side_effect=RuntimeError("network error"))
+
+        engine = CorrelationEngine(price_provider=provider)
+        config = PortfolioConfig(
+            currency="USD",
+            holdings=[Holding(ticker="AAPL", shares=100, avg_cost=150.0)],
+            limits=PortfolioLimits(),
+        )
+        calc = RiskCalculator(config, correlation_engine=engine)
+        result = await calc.assess_async({"AAPL": 180.0})
+
+        assert result.exposure.correlation_data_unavailable is True
+        assert len(result.warnings) == 1
+        assert "Correlation/beta data unavailable" in result.warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_assess_async_no_warnings_on_success(self) -> None:
+        from qracer.config.models import Holding, PortfolioConfig, PortfolioLimits
+        from qracer.risk.calculator import RiskCalculator
+
+        provider = AsyncMock()
+        closes = [100.0, 101.0, 102.0, 101.5, 103.0]
+        provider.get_ohlcv = AsyncMock(return_value=_make_bars(closes))
+
+        engine = CorrelationEngine(price_provider=provider)
+        config = PortfolioConfig(
+            currency="USD",
+            holdings=[Holding(ticker="AAPL", shares=100, avg_cost=150.0)],
+            limits=PortfolioLimits(),
+        )
+        calc = RiskCalculator(config, correlation_engine=engine)
+        result = await calc.assess_async({"AAPL": 180.0})
+
+        assert result.exposure.correlation_data_unavailable is False
+        assert result.warnings == []
+
+    @pytest.mark.asyncio
     async def test_assess_async(self) -> None:
         from qracer.config.models import Holding, PortfolioConfig, PortfolioLimits
         from qracer.risk.calculator import RiskCalculator


### PR DESCRIPTION
## Summary

- Add `correlation_data_unavailable` boolean flag to `ExposureBreakdown` model, set explicitly when `CorrelationEngine.compute()` returns `None`
- Add `warnings` list field to `RiskAssessment` model, populated with descriptive messages when correlation data is missing
- Replace the brittle `portfolio_beta == 0.0` check in `pipeline.py` with the proper `correlation_data_unavailable` flag (the old check had false positives for market-neutral portfolios)

Closes #97

## Why

PR #102 partially addressed silent correlation failures by detecting `portfolio_beta == 0.0` in `pipeline.py`, but this approach was indirect and could false-positive on legitimately market-neutral portfolios. This PR adds proper model-level flags so any consumer of `ExposureBreakdown` or `RiskAssessment` gets explicit notification when correlation data is missing.

## Changes

| File | Change |
|------|--------|
| `src/qracer/risk/models.py` | Added `correlation_data_unavailable: bool` to `ExposureBreakdown`, `warnings: list[str]` to `RiskAssessment` |
| `src/qracer/risk/calculator.py` | Set the flag in `build_exposure_async()` when correlation returns `None`; populate `warnings` in `assess_async()` |
| `src/qracer/tools/pipeline.py` | Use `exposure.correlation_data_unavailable` instead of `portfolio_beta == 0.0` |
| `tests/risk/test_correlation.py` | 4 new tests covering flag and warnings behavior |

## Test plan

- [x] `test_build_exposure_async_sets_flag_on_failure` — verifies flag is `True` when OHLCV fetch fails
- [x] `test_build_exposure_async_flag_false_on_success` — verifies flag is `False` on success
- [x] `test_assess_async_populates_warnings_on_failure` — verifies `RiskAssessment.warnings` is populated on failure
- [x] `test_assess_async_no_warnings_on_success` — verifies empty warnings on success
- [x] All 82 existing + new tests pass

https://claude.ai/code/session_01CYsVzatd5zoQkeLyseMKU8