### PR TITLE
fix: reject FinnhubAdapter instantiation without API key (closes #101)

### DIFF
--- a/src/qracer/data/finnhub_adapter.py
+++ b/src/qracer/data/finnhub_adapter.py
@@ -115,7 +115,9 @@ class FinnhubAdapter:
             raise ImportError(
                 "finnhub-python is not installed. Install it with: uv add finnhub-python"
             )
-        self._client = finnhub.Client(api_key=api_key or "")
+        if not api_key:
+            raise ValueError("FINNHUB_API_KEY is required. Get one at https://finnhub.io/register")
+        self._client = finnhub.Client(api_key=api_key)
 
     async def get_fundamentals(self, ticker: str) -> FundamentalData:
         """Get fundamental financial data for a ticker."""

--- a/tests/data/test_finnhub_adapter.py
+++ b/tests/data/test_finnhub_adapter.py
@@ -1,0 +1,41 @@
+"""Tests for FinnhubAdapter API key validation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestFinnhubAdapterInit:
+    """Test FinnhubAdapter constructor validation."""
+
+    @patch("qracer.data.finnhub_adapter._HAS_FINNHUB", False)
+    def test_missing_finnhub_raises(self) -> None:
+        from qracer.data.finnhub_adapter import FinnhubAdapter
+
+        with pytest.raises(ImportError, match="finnhub-python is not installed"):
+            FinnhubAdapter(api_key="test")
+
+    @patch("qracer.data.finnhub_adapter._HAS_FINNHUB", True)
+    def test_missing_api_key_raises(self) -> None:
+        from qracer.data.finnhub_adapter import FinnhubAdapter
+
+        with pytest.raises(ValueError, match="FINNHUB_API_KEY is required"):
+            FinnhubAdapter(api_key=None)
+
+    @patch("qracer.data.finnhub_adapter._HAS_FINNHUB", True)
+    def test_empty_api_key_raises(self) -> None:
+        from qracer.data.finnhub_adapter import FinnhubAdapter
+
+        with pytest.raises(ValueError, match="FINNHUB_API_KEY is required"):
+            FinnhubAdapter(api_key="")
+
+    @patch("qracer.data.finnhub_adapter._HAS_FINNHUB", True)
+    @patch("qracer.data.finnhub_adapter.finnhub", create=True)
+    def test_valid_api_key_succeeds(self, mock_finnhub: MagicMock) -> None:
+        from qracer.data.finnhub_adapter import FinnhubAdapter
+
+        adapter = FinnhubAdapter(api_key="valid-key")
+        mock_finnhub.Client.assert_called_once_with(api_key="valid-key")
+        assert adapter._client is mock_finnhub.Client.return_value


### PR DESCRIPTION
## Summary
- `FinnhubAdapter.__init__()`에서 `api_key`가 없거나 빈 문자열이면 `ValueError` 발생하도록 수정
- 기존에는 `api_key=None`으로 인스턴스 생성이 성공했지만, 실제 API 호출 시점에서야 인증 에러 발생
- FredAdapter와 동일한 fail-fast 패턴 적용
- 4개 유닛 테스트 추가 (`tests/data/test_finnhub_adapter.py`)

## Test plan
- [x] `uv run pytest tests/data/test_finnhub_adapter.py` — 4/4 passed
- [x] ruff check, ruff format, pyright 모두 통과

https://claude.ai/code/session_01UWm7fAjz4VihWdPTcKsHWG