### PR TITLE
fix: replace silent except patterns with logging and ToolResult tracking

### DIFF
--- a/src/qracer/agents/analyst.py
+++ b/src/qracer/agents/analyst.py
@@ -5,10 +5,14 @@ Pipeline steps: Macro Regime Detection (step 2), Cross-Market Discovery (step 3)
 
 from __future__ import annotations
 
+import logging
+
 from qracer.agents.base import BaseAgent
 from qracer.data.providers import MacroProvider, NewsProvider, PriceProvider
 from qracer.llm.providers import Role
 from qracer.models import ToolResult
+
+logger = logging.getLogger(__name__)
 
 
 class Analyst(BaseAgent):
@@ -59,7 +63,7 @@ class Analyst(BaseAgent):
                         )
                     )
         except KeyError:
-            pass  # no MacroProvider registered
+            logger.debug("MacroProvider not registered, skipping regime indicators")
 
         data_text = self._format_tool_data(self._successful_results(results))
         return await self._complete_json(
@@ -117,7 +121,7 @@ class Analyst(BaseAgent):
                         )
                     )
         except KeyError:
-            pass
+            logger.debug("PriceProvider not registered, skipping price data")
 
         # News data
         try:
@@ -139,9 +143,17 @@ class Analyst(BaseAgent):
                         )
                     )
                 except Exception:
-                    pass  # news is supplementary
+                    results.append(
+                        ToolResult(
+                            tool="news",
+                            success=False,
+                            data={},
+                            source="NewsProvider",
+                            error=f"News fetch failed for {ticker}",
+                        )
+                    )
         except KeyError:
-            pass
+            logger.debug("NewsProvider not registered, skipping news data")
 
         data_text = self._format_tool_data(self._successful_results(results))
         return await self._complete_json(

--- a/src/qracer/agents/researcher.py
+++ b/src/qracer/agents/researcher.py
@@ -5,6 +5,8 @@ Pipeline steps: Universe Screening (step 1), Consensus Mapping (step 4).
 
 from __future__ import annotations
 
+import logging
+
 from qracer.agents.base import BaseAgent
 from qracer.data.providers import (
     FundamentalProvider,
@@ -12,6 +14,8 @@ from qracer.data.providers import (
 )
 from qracer.llm.providers import Role
 from qracer.models import Stock, ToolResult
+
+logger = logging.getLogger(__name__)
 
 
 class Researcher(BaseAgent):
@@ -69,7 +73,7 @@ class Researcher(BaseAgent):
                         )
                     )
         except KeyError:
-            pass  # no FundamentalProvider registered
+            logger.debug("FundamentalProvider not registered, skipping fundamentals screening")
 
         successful = self._successful_results(results)
         if not successful:

--- a/src/qracer/tools/pipeline.py
+++ b/src/qracer/tools/pipeline.py
@@ -460,6 +460,7 @@ async def memory_search(query: str, searcher: Any = None, **kwargs: object) -> T
                 ],
             }
         except Exception:
+            logger.debug("memory_search query failed for '%s'", query, exc_info=True)
             return {"query": query, "results": []}
 
     return await _run_tool("memory_search", "SessionMemory", _fetch, label=query, stale_check=False)


### PR DESCRIPTION
Closes #114

## Summary

- **analyst.py**: `except KeyError: pass` 3곳에 `logger.debug()` 추가, 뉴스 fetch `except Exception: pass`를 `ToolResult(success=False)` 기록으로 변경
- **researcher.py**: `except KeyError: pass` 1곳에 `logger.debug()` 추가
- **pipeline.py**: `memory_search` 내부 예외에 `logger.debug()` 추가

## Why

Agent 레이어에서 missing provider와 fetch 실패가 `pass`로 무시되면:
1. 디버깅 시 어떤 프로바이더가 빠졌는지 추적 불가
2. `ToolResult(success=False)`가 기록되지 않아 synthesizer의 `failed_tools` 목록에 누락 → adversarial check에 데이터 한계가 반영되지 않음

`researcher.py:map_consensus()`가 이미 올바른 패턴을 사용하고 있어 이를 표준으로 통일.

## Test plan

- [x] `uv run pytest tests/agents/ -v` — 26 passed
- [x] `uv run pytest tests/tools/ -v` — 24 passed
- [x] `uv run ruff check` — All checks passed
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)