### PR TITLE
fix: flaky should_check test — use None sentinel instead of 0.0

### DIFF
--- a/src/qracer/alert_monitor.py
+++ b/src/qracer/alert_monitor.py
@@ -39,7 +39,7 @@ class AlertMonitor:
         self._store = store
         self._data_registry = data_registry
         self._check_interval = check_interval
-        self._last_check: float = 0.0
+        self._last_check: float | None = None
 
     @property
     def store(self) -> AlertStore:
@@ -47,6 +47,8 @@ class AlertMonitor:
 
     def should_check(self) -> bool:
         """Return True if enough time has elapsed since the last check."""
+        if self._last_check is None:
+            return True
         return (time.monotonic() - self._last_check) >= self._check_interval
 
     async def check(self) -> list[AlertResult]:


### PR DESCRIPTION
## Summary

- `AlertMonitor._last_check`를 `0.0` → `None`으로 변경
- `should_check()`에서 `None`이면 즉시 `True` 반환

## Why

`time.monotonic()`는 시스템 부팅 후 경과 시간. CI 컨테이너가 부팅 후 60초 미만이면 `monotonic() - 0.0 < 60`이 되어 첫 `should_check()`가 `False` 반환. 이 flaky test가 #104, #107, #120의 CI를 모두 블로킹 중.

## Test plan

- [x] `uv run pytest tests/test_alert_monitor.py -v` — 10 passed
- [x] `uv run ruff check` — passed
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)