### PR TITLE
refactor: externalize hardcoded analysis and pipeline params to config

### DIFF
--- a/src/qracer/cli.py
+++ b/src/qracer/cli.py
@@ -619,6 +619,16 @@ def repl() -> None:
     if provider_warnings:
         click.echo()
 
+    # Apply config-driven pipeline defaults.
+    from qracer.config.loader import load_config
+    from qracer.tools.pipeline import configure as configure_pipeline
+
+    app_cfg = load_config().app
+    configure_pipeline(
+        lookback_days=app_cfg.lookback_days,
+        staleness_hours=app_cfg.staleness_hours,
+    )
+
     # Create session logger in ~/.qracer/sessions/<uuid>.jsonl
     sessions_dir = _user_dir() / "sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
@@ -635,6 +645,8 @@ def repl() -> None:
     engine = ConversationEngine(
         llm_registry,
         data_registry,
+        max_iterations=app_cfg.max_iterations,
+        confidence_threshold=app_cfg.confidence_threshold,
         session_logger=session_logger,
         report_dir=reports_dir,
     )

--- a/src/qracer/config/models.py
+++ b/src/qracer/config/models.py
@@ -15,6 +15,14 @@ class AppConfig(BaseModel):
     llm_model: str = "claude-sonnet-4-20250514"
     language: str = "en"
 
+    # Analysis loop tuning
+    max_iterations: int = 3
+    confidence_threshold: float = 0.7
+
+    # Pipeline defaults
+    lookback_days: int = 30
+    staleness_hours: int = 24
+
 
 class ProviderConfig(BaseModel):
     """Single provider entry inside providers.toml."""

--- a/src/qracer/config/schema/config.toml
+++ b/src/qracer/config/schema/config.toml
@@ -5,3 +5,11 @@ default_mode = "quick"        # "quick" or "deep"
 llm_provider = "claude"
 llm_model = "claude-sonnet-4-20250514"
 language = "en"
+
+# Analysis loop tuning
+max_iterations = 3            # max reasoning iterations before returning
+confidence_threshold = 0.7    # 0.0–1.0, stop early when confidence exceeds this
+
+# Pipeline defaults
+lookback_days = 30            # days of price history to fetch
+staleness_hours = 24          # hours before data is considered stale

--- a/src/qracer/tools/pipeline.py
+++ b/src/qracer/tools/pipeline.py
@@ -33,6 +33,15 @@ _DEFAULT_LOOKBACK_DAYS = 30
 _STALENESS_HOURS = 24
 
 
+def configure(*, lookback_days: int | None = None, staleness_hours: int | None = None) -> None:
+    """Override pipeline defaults from config.  Called once at startup."""
+    global _DEFAULT_LOOKBACK_DAYS, _STALENESS_HOURS  # noqa: PLW0603
+    if lookback_days is not None:
+        _DEFAULT_LOOKBACK_DAYS = lookback_days
+    if staleness_hours is not None:
+        _STALENESS_HOURS = staleness_hours
+
+
 def _is_stale(fetched_at: datetime, threshold_hours: int = _STALENESS_HOURS) -> bool:
     return (datetime.now() - fetched_at).total_seconds() > threshold_hours * 3600
 


### PR DESCRIPTION
Closes #116

## Summary

- `AppConfig`에 4개 필드 추가: `max_iterations`, `confidence_threshold`, `lookback_days`, `staleness_hours`
- `config.toml` 스키마에 주석 포함 문서화
- `pipeline.configure()` 함수 추가 — CLI에서 startup 시 호출
- CLI에서 `load_config().app` → Engine + pipeline에 값 전달

## 외부화하지 않은 것들 (+ 이유)

| 항목 | 이유 |
|------|------|
| 섹터 매핑 (`calculator.py`) | FundamentalProvider fallback이 이미 있음, config보다 데이터 소스가 적절 |
| 모델 매핑 / 비용 (`claude_adapter.py`) | 프로바이더별 내부 구현, providers.toml + LLM registry가 이미 처리 |

## Test plan

- [x] `uv run pytest tests/ -v` — 521 passed (4 failed는 Windows cp949 로캘 기존 이슈, main에서도 동일)
- [x] `uv run ruff check` — All checks passed
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)