### PR TITLE
refactor: propagate config changes to engine and pipeline at runtime

### DIFF
--- a/src/qracer/cli.py
+++ b/src/qracer/cli.py
@@ -412,7 +412,19 @@ async def _repl_loop(
         if has_config_changed():
             try:
                 llm_reg, data_reg, reload_warnings = _build_registries()
-                engine.update_registries(llm_reg, data_reg)  # type: ignore[attr-defined]
+
+                # Re-read config for portfolio and pipeline updates.
+                from qracer.tools.pipeline import configure as configure_pipeline
+
+                reloaded = load_config(force_reload=True)
+                configure_pipeline(
+                    lookback_days=reloaded.app.lookback_days,
+                    staleness_hours=reloaded.app.staleness_hours,
+                )
+
+                engine.update_registries(  # type: ignore[attr-defined]
+                    llm_reg, data_reg, portfolio_config=reloaded.portfolio
+                )
                 click.echo("⟳ Configuration reloaded.")
                 for warn in reload_warnings:
                     click.echo(f"  ⚠ {warn}")

--- a/src/qracer/conversation/engine.py
+++ b/src/qracer/conversation/engine.py
@@ -109,11 +109,19 @@ class ConversationEngine:
         self._last_response: EngineResponse | None = None
         self._config_version = 0
 
-    def update_registries(self, llm_registry: LLMRegistry, data_registry: DataRegistry) -> None:
-        """Hot-swap registries when config changes at runtime."""
+    def update_registries(
+        self,
+        llm_registry: LLMRegistry,
+        data_registry: DataRegistry,
+        portfolio_config: PortfolioConfig | None = None,
+    ) -> None:
+        """Hot-swap registries and optionally portfolio config at runtime."""
         self._llm = llm_registry
         self._data = data_registry
         self._intent_parser = IntentParser(llm_registry)
+
+        if portfolio_config is not None:
+            self._portfolio_config = portfolio_config
 
         analysis_loop = AnalysisLoop(
             llm_registry,


### PR DESCRIPTION
Closes #119

## Summary

- `Engine.update_registries()`에 `portfolio_config` 파라미터 추가 — 전달 시 모든 핸들러가 새 portfolio로 재생성
- CLI hot-reload 블록에서 `load_config(force_reload=True)` 호출 후 `pipeline.configure()` + `engine.update_registries(portfolio_config=...)` 호출

## Before / After

**Before**: REPL 세션 중 `portfolio.toml`이나 `config.toml` 수정 시 registries만 갱신, portfolio/pipeline 설정은 재시작 전까지 반영 안 됨

**After**: 파일 변경 감지 시 portfolio holdings, lookback_days, staleness_hours 모두 자동 반영

## Test plan

- [x] `uv run pytest tests/conversation/test_engine.py -v` — 30 passed
- [x] `uv run ruff check` — All checks passed
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)