### PR TITLE
refactor: eliminate sync/async code duplication in RiskCalculator and Synthesizer

### DIFF
--- a/src/qracer/conversation/synthesizer.py
+++ b/src/qracer/conversation/synthesizer.py
@@ -14,6 +14,20 @@ from qracer.models import ToolResult
 logger = logging.getLogger(__name__)
 
 
+def _format_fallback(
+    header: str,
+    query: str,
+    tool_lines: list[str],
+    closing: str,
+) -> str:
+    """Shared fallback formatter used when the LLM is unavailable."""
+    lines = [header, f"Query: {query}", ""]
+    lines.extend(tool_lines)
+    lines.append("")
+    lines.append(closing)
+    return "\n".join(lines)
+
+
 class ResponseSynthesizer:
     """Synthesizes a final response from analysis results.
 
@@ -86,16 +100,14 @@ class ResponseSynthesizer:
 
     def _fallback_response(self, intent: Intent, analysis: AnalysisResult) -> str:
         """Minimal plain-text fallback when the LLM is unavailable."""
-        lines = [f"[ANALYSIS: {', '.join(intent.tickers) or 'general'}]"]
-        lines.append(f"Query: {intent.raw_query}")
-        lines.append(f"Confidence: {analysis.confidence:.2f}")
-        lines.append("")
+        header = f"[ANALYSIS: {', '.join(intent.tickers) or 'general'}]"
+        tool_lines = [f"Confidence: {analysis.confidence:.2f}", ""]
         for r in analysis.results:
             status = "OK" if r.success else f"FAILED ({r.error})"
-            lines.append(f"  [{r.tool}] {status}")
-        lines.append("")
-        lines.append("(Full synthesis unavailable — LLM error)")
-        return "\n".join(lines)
+            tool_lines.append(f"  [{r.tool}] {status}")
+        return _format_fallback(
+            header, intent.raw_query, tool_lines, "(Full synthesis unavailable — LLM error)"
+        )
 
 
 class ComparisonSynthesizer:
@@ -156,14 +168,13 @@ class ComparisonSynthesizer:
     def _fallback_response(
         self, intent: Intent, per_ticker_results: dict[str, list[ToolResult]]
     ) -> str:
-        lines = [f"[COMPARISON: {', '.join(intent.tickers)}]"]
-        lines.append(f"Query: {intent.raw_query}")
-        lines.append("")
+        header = f"[COMPARISON: {', '.join(intent.tickers)}]"
+        tool_lines: list[str] = []
         for ticker, results in per_ticker_results.items():
-            lines.append(f"  {ticker}:")
+            tool_lines.append(f"  {ticker}:")
             for r in results:
                 status = "OK" if r.success else f"FAILED ({r.error})"
-                lines.append(f"    [{r.tool}] {status}")
-        lines.append("")
-        lines.append("(Full comparison unavailable — LLM error)")
-        return "\n".join(lines)
+                tool_lines.append(f"    [{r.tool}] {status}")
+        return _format_fallback(
+            header, intent.raw_query, tool_lines, "(Full comparison unavailable — LLM error)"
+        )

--- a/src/qracer/risk/calculator.py
+++ b/src/qracer/risk/calculator.py
@@ -174,15 +174,15 @@ class RiskCalculator:
             as_of=datetime.now(),
         )
 
-    def build_exposure(self, snapshot: PortfolioSnapshot) -> ExposureBreakdown:
-        """Build exposure breakdown from a portfolio snapshot."""
-        sector_values: dict[str, float] = {}
+    @staticmethod
+    def _sector_exposure(
+        sector_values: dict[str, float],
+        total: float,
+    ) -> tuple[dict[str, float], str, float]:
+        """Compute sector weights and top sector from sector market values.
 
-        for h in snapshot.holdings:
-            sector = self._sectors.get_sector(h.ticker)
-            sector_values[sector] = sector_values.get(sector, 0.0) + h.market_value
-
-        total = snapshot.total_value
+        Returns (sector_weights, top_sector, top_sector_pct).
+        """
         sector_weights: dict[str, float] = {}
         for sector, value in sector_values.items():
             sector_weights[sector] = round(value / total * 100.0, 2) if total > 0 else 0.0
@@ -193,6 +193,31 @@ class RiskCalculator:
         else:
             top_sector = "N/A"
             top_sector_pct = 0.0
+
+        return sector_weights, top_sector, top_sector_pct
+
+    def _resolve_sector_values(self, snapshot: PortfolioSnapshot) -> dict[str, float]:
+        """Aggregate market values by sector using sync resolver."""
+        sector_values: dict[str, float] = {}
+        for h in snapshot.holdings:
+            sector = self._sectors.get_sector(h.ticker)
+            sector_values[sector] = sector_values.get(sector, 0.0) + h.market_value
+        return sector_values
+
+    async def _resolve_sector_values_async(self, snapshot: PortfolioSnapshot) -> dict[str, float]:
+        """Aggregate market values by sector using async resolver."""
+        sector_values: dict[str, float] = {}
+        for h in snapshot.holdings:
+            sector = await self._sectors.get_sector_async(h.ticker)
+            sector_values[sector] = sector_values.get(sector, 0.0) + h.market_value
+        return sector_values
+
+    def build_exposure(self, snapshot: PortfolioSnapshot) -> ExposureBreakdown:
+        """Build exposure breakdown from a portfolio snapshot."""
+        sector_values = self._resolve_sector_values(snapshot)
+        sector_weights, top_sector, top_sector_pct = self._sector_exposure(
+            sector_values, snapshot.total_value
+        )
 
         return ExposureBreakdown(
             sector_weights=sector_weights,
@@ -204,23 +229,10 @@ class RiskCalculator:
 
     async def build_exposure_async(self, snapshot: PortfolioSnapshot) -> ExposureBreakdown:
         """Build exposure breakdown with async sector lookup and correlation/beta."""
-        # Async sector lookup via FundamentalProvider (falls back to hardcoded).
-        sector_values: dict[str, float] = {}
-        for h in snapshot.holdings:
-            sector = await self._sectors.get_sector_async(h.ticker)
-            sector_values[sector] = sector_values.get(sector, 0.0) + h.market_value
-
-        total = snapshot.total_value
-        sector_weights: dict[str, float] = {}
-        for sector, value in sector_values.items():
-            sector_weights[sector] = round(value / total * 100.0, 2) if total > 0 else 0.0
-
-        if sector_weights:
-            top_sector = max(sector_weights, key=lambda s: sector_weights[s])
-            top_sector_pct = sector_weights[top_sector]
-        else:
-            top_sector = "N/A"
-            top_sector_pct = 0.0
+        sector_values = await self._resolve_sector_values_async(snapshot)
+        sector_weights, top_sector, top_sector_pct = self._sector_exposure(
+            sector_values, snapshot.total_value
+        )
 
         # Correlation/beta computation.
         portfolio_beta: float | None = None
@@ -331,12 +343,14 @@ class RiskCalculator:
             return 0.0
         return (self._peak_value - current_value) / self._peak_value * 100.0
 
-    def assess(self, prices: dict[str, float]) -> RiskAssessment:
-        """Run a full risk assessment."""
-        snapshot = self.build_snapshot(prices)
-        exposure = self.build_exposure(snapshot)
+    def _build_assessment(
+        self,
+        snapshot: PortfolioSnapshot,
+        exposure: ExposureBreakdown,
+        warnings: list[str] | None = None,
+    ) -> RiskAssessment:
+        """Shared logic for building a RiskAssessment from snapshot + exposure."""
         breached = self.check_limits(snapshot, exposure)
-
         self.update_peak(snapshot.total_value)
         drawdown_pct = self.compute_drawdown(snapshot.total_value)
         alert_threshold = self._config.limits.max_drawdown_alert_pct
@@ -346,21 +360,22 @@ class RiskCalculator:
             snapshot=snapshot,
             exposure=exposure,
             limits_breached=breached,
+            warnings=warnings or [],
             max_drawdown_alert=drawdown_alert,
             current_drawdown_pct=round(drawdown_pct, 2),
             peak_value=round(self._peak_value, 2),
         )
 
+    def assess(self, prices: dict[str, float]) -> RiskAssessment:
+        """Run a full risk assessment."""
+        snapshot = self.build_snapshot(prices)
+        exposure = self.build_exposure(snapshot)
+        return self._build_assessment(snapshot, exposure)
+
     async def assess_async(self, prices: dict[str, float]) -> RiskAssessment:
         """Run a full risk assessment with async correlation/beta computation."""
         snapshot = self.build_snapshot(prices)
         exposure = await self.build_exposure_async(snapshot)
-        breached = self.check_limits(snapshot, exposure)
-
-        self.update_peak(snapshot.total_value)
-        drawdown_pct = self.compute_drawdown(snapshot.total_value)
-        alert_threshold = self._config.limits.max_drawdown_alert_pct
-        drawdown_alert = drawdown_pct > alert_threshold
 
         warnings: list[str] = []
         if exposure.correlation_data_unavailable:
@@ -369,12 +384,4 @@ class RiskCalculator:
                 "proceeded without correlation adjustments"
             )
 
-        return RiskAssessment(
-            snapshot=snapshot,
-            exposure=exposure,
-            limits_breached=breached,
-            warnings=warnings,
-            max_drawdown_alert=drawdown_alert,
-            current_drawdown_pct=round(drawdown_pct, 2),
-            peak_value=round(self._peak_value, 2),
-        )
+        return self._build_assessment(snapshot, exposure, warnings)


### PR DESCRIPTION
Closes #115

## Summary

- **RiskCalculator**: Extracted 3 shared helpers to eliminate duplicated logic between sync/async method pairs:
  - `_sector_exposure()` — computes sector weights and top sector from sector market values (was duplicated in `build_exposure` and `build_exposure_async`)
  - `_resolve_sector_values()` / `_resolve_sector_values_async()` — separated the sector resolution step (sync vs async) from the shared weight computation
  - `_build_assessment()` — shared logic for `assess()` and `assess_async()` (limits check, drawdown, peak tracking)
- **Synthesizer**: Extracted `_format_fallback()` module-level helper used by both `ResponseSynthesizer._fallback_response()` and `ComparisonSynthesizer._fallback_response()`

## Why

Sync/async method pairs duplicated ~90% identical logic. Modifying one side without the other is a common source of bugs. The extracted helpers make the shared logic a single source of truth while keeping sync and async entry points separate.

## Test plan

- [x] `uv run pytest tests/risk/test_calculator.py -v` — 43 passed
- [x] `uv run ruff check` — All checks passed
- [x] `uv run pyright` — 0 errors, 0 warnings

https://claude.ai/code/session_01KnYbuBYz2tcxRk8wbVxsJC