### PR TITLE
feat: export analysis reports as PDF (closes #138)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
   "tomli>=2.0.0; python_version < '3.11'",
 ]
 
+[project.optional-dependencies]
+pdf = ["fpdf2>=2.7.0"]
+
 [dependency-groups]
 dev = [
   "ruff>=0.9.0",

--- a/src/tracer/cli.py
+++ b/src/tracer/cli.py
@@ -26,6 +26,7 @@ BANNER = """\
 ║  Tracer — conversational alpha engine    ║
 ╚══════════════════════════════════════════╝
 Type your query, or 'quit' to exit.
+Commands: save [md|json|pdf]
 """
 
 
@@ -257,6 +258,21 @@ async def _repl_loop(engine: object) -> None:
         if user_input.lower() in ("quit", "exit", "q"):
             click.echo("Goodbye.")
             break
+
+        # Handle save commands: "save pdf", "/save json", etc.
+        normalised = user_input.lstrip("/").lower()
+        if normalised.startswith("save"):
+            parts = normalised.split()
+            fmt = parts[1] if len(parts) > 1 else "md"
+            if fmt not in ("md", "json", "pdf"):
+                click.echo(f"Unknown format '{fmt}'. Use: md, json, pdf\n")
+                continue
+            path = engine.save_last_report(fmt)  # type: ignore[attr-defined]
+            if path is None:
+                click.echo("No analysis to save yet. Run a query first.\n")
+            else:
+                click.echo(f"Report saved to {path}\n")
+            continue
 
         try:
             response = await engine.query(user_input)  # type: ignore[attr-defined]

--- a/src/tracer/conversation/__init__.py
+++ b/src/tracer/conversation/__init__.py
@@ -11,6 +11,7 @@ from tracer.conversation.intent import (
     IntentParser,
     IntentType,
 )
+from tracer.conversation.report_exporter import ReportExporter
 
 __all__ = [
     "AnalysisLoop",
@@ -21,5 +22,6 @@ __all__ = [
     "Intent",
     "IntentParser",
     "IntentType",
+    "ReportExporter",
     "ResponseSynthesizer",
 ]

--- a/src/tracer/conversation/engine.py
+++ b/src/tracer/conversation/engine.py
@@ -12,9 +12,12 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from pathlib import Path
+
 from tracer.config.models import PortfolioConfig
 from tracer.conversation.context import ConversationContext, extract_context, resolve_pronoun
 from tracer.conversation.intent import Intent, IntentParser
+from tracer.conversation.report_exporter import ReportExporter
 from tracer.data.registry import DataRegistry, build_registry
 from tracer.llm.providers import CompletionRequest, CompletionResponse, Message, Role
 from tracer.llm.registry import LLMRegistry
@@ -332,6 +335,8 @@ class ConversationEngine:
         self._history: list[dict] = []
         self._session_logger = session_logger
         self._context: ConversationContext = ConversationContext()
+        self._last_response: EngineResponse | None = None
+        self._exporter = ReportExporter()
 
     @property
     def history(self) -> list[dict]:
@@ -417,11 +422,35 @@ class ConversationEngine:
 
         self._history.append({"role": "assistant", "content": text})
 
-        return EngineResponse(
+        resp = EngineResponse(
             text=text,
             intent=intent,
             analysis=analysis,
         )
+        self._last_response = resp
+        return resp
+
+    def save_last_report(self, fmt: str = "md", output_dir: Path | None = None) -> Path | None:
+        """Save the most recent analysis response to a file.
+
+        Args:
+            fmt: Output format — ``"md"``, ``"json"``, or ``"pdf"``.
+            output_dir: Override the default output directory.
+
+        Returns:
+            Path to the saved file, or ``None`` if no response is available.
+        """
+        if self._last_response is None:
+            return None
+
+        if output_dir is not None:
+            self._exporter._output_dir = output_dir
+
+        if fmt == "json":
+            return self._exporter.save_json(self._last_response)
+        if fmt == "pdf":
+            return self._exporter.save_pdf(self._last_response)
+        return self._exporter.save_markdown(self._last_response)
 
 
 def _format_evidence(results: list[ToolResult]) -> str:

--- a/src/tracer/conversation/report_exporter.py
+++ b/src/tracer/conversation/report_exporter.py
@@ -1,0 +1,208 @@
+"""ReportExporter — save analysis results as Markdown, JSON, or PDF."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tracer.conversation.engine import EngineResponse
+
+logger = logging.getLogger(__name__)
+
+
+class ReportExporter:
+    """Export an EngineResponse to various file formats."""
+
+    def __init__(self, output_dir: Path | None = None) -> None:
+        self._output_dir = output_dir or Path.cwd()
+
+    def _ensure_dir(self) -> None:
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+
+    def _build_filename(self, response: EngineResponse, ext: str) -> Path:
+        tickers = "_".join(response.intent.tickers) if response.intent.tickers else "general"
+        ts = response.generated_at.strftime("%Y%m%d_%H%M%S")
+        return self._output_dir / f"tracer_{tickers}_{ts}.{ext}"
+
+    # ------------------------------------------------------------------
+    # Markdown
+    # ------------------------------------------------------------------
+
+    def save_markdown(self, response: EngineResponse) -> Path:
+        """Save the analysis as a Markdown file."""
+        self._ensure_dir()
+        path = self._build_filename(response, "md")
+
+        lines: list[str] = []
+        ticker_str = ", ".join(response.intent.tickers) if response.intent.tickers else "General"
+        ts = response.generated_at.strftime("%Y-%m-%d %H:%M:%S")
+
+        lines.append(f"# Analysis: {ticker_str}")
+        lines.append(f"*Generated: {ts}*\n")
+        lines.append(response.text)
+        lines.append("")
+
+        # Trade thesis section
+        thesis = response.analysis.trade_thesis
+        if thesis is not None:
+            lines.append("## Trade Thesis")
+            lines.append(f"- **Entry Zone:** ${thesis.entry_zone[0]:.2f} – ${thesis.entry_zone[1]:.2f}")
+            lines.append(f"- **Target Price:** ${thesis.target_price:.2f}")
+            lines.append(f"- **Stop Loss:** ${thesis.stop_loss:.2f}")
+            lines.append(f"- **Risk/Reward:** {thesis.risk_reward_ratio:.2f}")
+            lines.append(f"- **Conviction:** {thesis.conviction}/10")
+            lines.append(f"- **Catalyst:** {thesis.catalyst}")
+            lines.append(f"\n{thesis.summary}")
+            lines.append("")
+
+        # Data sources
+        lines.append("## Data Sources")
+        for r in response.analysis.results:
+            status = "OK" if r.success else f"FAILED ({r.error})"
+            lines.append(f"- **{r.tool}** ({r.source}): {status}")
+        lines.append("")
+
+        path.write_text("\n".join(lines), encoding="utf-8")
+        logger.info("Saved Markdown report to %s", path)
+        return path
+
+    # ------------------------------------------------------------------
+    # JSON
+    # ------------------------------------------------------------------
+
+    def save_json(self, response: EngineResponse) -> Path:
+        """Save the analysis as a JSON file."""
+        self._ensure_dir()
+        path = self._build_filename(response, "json")
+
+        thesis_data = None
+        thesis = response.analysis.trade_thesis
+        if thesis is not None:
+            thesis_data = {
+                "ticker": thesis.ticker,
+                "entry_zone": list(thesis.entry_zone),
+                "target_price": thesis.target_price,
+                "stop_loss": thesis.stop_loss,
+                "risk_reward_ratio": thesis.risk_reward_ratio,
+                "catalyst": thesis.catalyst,
+                "catalyst_date": thesis.catalyst_date,
+                "conviction": thesis.conviction,
+                "summary": thesis.summary,
+            }
+
+        payload = {
+            "title": f"Analysis: {', '.join(response.intent.tickers) or 'General'}",
+            "generated_at": response.generated_at.isoformat(),
+            "intent": {
+                "type": response.intent.intent_type.value,
+                "tickers": response.intent.tickers,
+                "tools": response.intent.tools,
+                "raw_query": response.intent.raw_query,
+            },
+            "response_text": response.text,
+            "analysis": {
+                "confidence": response.analysis.confidence,
+                "iterations": response.analysis.iterations,
+                "early_exit_reason": response.analysis.early_exit_reason,
+                "trade_thesis": thesis_data,
+            },
+            "data_sources": [
+                {
+                    "tool": r.tool,
+                    "source": r.source,
+                    "success": r.success,
+                    "error": r.error,
+                }
+                for r in response.analysis.results
+            ],
+        }
+
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        logger.info("Saved JSON report to %s", path)
+        return path
+
+    # ------------------------------------------------------------------
+    # PDF
+    # ------------------------------------------------------------------
+
+    def save_pdf(self, response: EngineResponse) -> Path:
+        """Save the analysis as a formatted PDF file.
+
+        Requires the optional ``fpdf2`` dependency:
+            pip install tracer[pdf]
+        """
+        try:
+            from fpdf import FPDF
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "PDF export requires fpdf2. Install it with: pip install tracer[pdf]"
+            ) from exc
+
+        self._ensure_dir()
+        path = self._build_filename(response, "pdf")
+
+        ticker_str = ", ".join(response.intent.tickers) if response.intent.tickers else "General"
+        ts = response.generated_at.strftime("%Y-%m-%d %H:%M:%S")
+
+        pdf = FPDF()
+        pdf.set_auto_page_break(auto=True, margin=15)
+        pdf.add_page()
+
+        # --- Header ---
+        pdf.set_font("Helvetica", "B", 16)
+        pdf.cell(0, 10, f"Analysis: {ticker_str}", new_x="LMARGIN", new_y="NEXT")
+        pdf.set_font("Helvetica", "", 10)
+        pdf.set_text_color(100, 100, 100)
+        pdf.cell(0, 6, f"Generated: {ts}", new_x="LMARGIN", new_y="NEXT")
+        pdf.set_text_color(0, 0, 0)
+        pdf.ln(4)
+
+        # --- Response body ---
+        pdf.set_font("Helvetica", "B", 12)
+        pdf.cell(0, 8, "Response", new_x="LMARGIN", new_y="NEXT")
+        pdf.set_font("Helvetica", "", 10)
+        pdf.multi_cell(0, 5, response.text)
+        pdf.ln(4)
+
+        # --- Trade thesis ---
+        thesis = response.analysis.trade_thesis
+        if thesis is not None:
+            pdf.set_font("Helvetica", "B", 12)
+            pdf.cell(0, 8, "Trade Thesis", new_x="LMARGIN", new_y="NEXT")
+            pdf.set_font("Helvetica", "", 10)
+
+            rows = [
+                ("Entry Zone", f"${thesis.entry_zone[0]:.2f} - ${thesis.entry_zone[1]:.2f}"),
+                ("Target Price", f"${thesis.target_price:.2f}"),
+                ("Stop Loss", f"${thesis.stop_loss:.2f}"),
+                ("Risk/Reward", f"{thesis.risk_reward_ratio:.2f}"),
+                ("Conviction", f"{thesis.conviction}/10"),
+                ("Catalyst", thesis.catalyst),
+            ]
+            for label, value in rows:
+                pdf.set_font("Helvetica", "B", 10)
+                pdf.cell(40, 6, f"{label}:")
+                pdf.set_font("Helvetica", "", 10)
+                pdf.cell(0, 6, value, new_x="LMARGIN", new_y="NEXT")
+
+            pdf.ln(2)
+            pdf.set_font("Helvetica", "", 10)
+            pdf.multi_cell(0, 5, thesis.summary)
+            pdf.ln(4)
+
+        # --- Data sources ---
+        pdf.set_font("Helvetica", "B", 12)
+        pdf.cell(0, 8, "Data Sources", new_x="LMARGIN", new_y="NEXT")
+        pdf.set_font("Helvetica", "", 10)
+
+        for r in response.analysis.results:
+            status = "OK" if r.success else f"FAILED ({r.error})"
+            pdf.cell(0, 6, f"  {r.tool} ({r.source}): {status}", new_x="LMARGIN", new_y="NEXT")
+
+        pdf.output(str(path))
+        logger.info("Saved PDF report to %s", path)
+        return path

--- a/tests/conversation/test_report_exporter.py
+++ b/tests/conversation/test_report_exporter.py
@@ -1,0 +1,181 @@
+"""Tests for ReportExporter — Markdown, JSON, and PDF export."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from tracer.conversation.engine import AnalysisResult, EngineResponse
+from tracer.conversation.intent import Intent, IntentType
+from tracer.conversation.report_exporter import ReportExporter
+from tracer.models import ToolResult, TradeThesis
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_response(*, with_thesis: bool = True) -> EngineResponse:
+    """Build a minimal EngineResponse for testing."""
+    intent = Intent(
+        intent_type=IntentType.DEEP_DIVE,
+        tickers=["AAPL"],
+        tools=["price_event", "fundamentals"],
+        raw_query="deep dive AAPL",
+    )
+
+    tool_results = [
+        ToolResult(tool="price_event", success=True, data={"price": 185.0}, source="yfinance"),
+        ToolResult(
+            tool="fundamentals",
+            success=False,
+            data={},
+            source="yfinance",
+            error="timeout",
+        ),
+    ]
+
+    thesis = None
+    if with_thesis:
+        thesis = TradeThesis(
+            ticker="AAPL",
+            entry_zone=(180.0, 185.0),
+            target_price=210.0,
+            stop_loss=170.0,
+            risk_reward_ratio=2.0,
+            catalyst="Q2 earnings beat",
+            catalyst_date="2026-07-01",
+            conviction=7,
+            summary="AAPL looks strong heading into earnings.",
+        )
+
+    analysis = AnalysisResult(
+        results=tool_results,
+        confidence=0.8,
+        iterations=2,
+        trade_thesis=thesis,
+    )
+
+    return EngineResponse(
+        text="AAPL analysis response text.",
+        intent=intent,
+        analysis=analysis,
+        generated_at=datetime(2026, 4, 7, 12, 0, 0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown tests
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMarkdown:
+    def test_creates_md_file(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_markdown(_make_response())
+
+        assert path.exists()
+        assert path.suffix == ".md"
+        assert "AAPL" in path.name
+
+    def test_content_includes_key_sections(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_markdown(_make_response())
+        content = path.read_text()
+
+        assert "# Analysis: AAPL" in content
+        assert "Trade Thesis" in content
+        assert "$180.00" in content
+        assert "Data Sources" in content
+        assert "FAILED (timeout)" in content
+
+    def test_without_thesis(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_markdown(_make_response(with_thesis=False))
+        content = path.read_text()
+
+        assert "Trade Thesis" not in content
+
+
+# ---------------------------------------------------------------------------
+# JSON tests
+# ---------------------------------------------------------------------------
+
+
+class TestSaveJson:
+    def test_creates_json_file(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_json(_make_response())
+
+        assert path.exists()
+        assert path.suffix == ".json"
+
+    def test_valid_json_structure(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_json(_make_response())
+        data = json.loads(path.read_text())
+
+        assert data["title"] == "Analysis: AAPL"
+        assert data["intent"]["tickers"] == ["AAPL"]
+        assert data["analysis"]["confidence"] == 0.8
+        assert data["analysis"]["trade_thesis"]["conviction"] == 7
+        assert len(data["data_sources"]) == 2
+
+    def test_without_thesis(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_json(_make_response(with_thesis=False))
+        data = json.loads(path.read_text())
+
+        assert data["analysis"]["trade_thesis"] is None
+
+
+# ---------------------------------------------------------------------------
+# PDF tests
+# ---------------------------------------------------------------------------
+
+
+class TestSavePdf:
+    def test_creates_pdf_file(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_pdf(_make_response())
+
+        assert path.exists()
+        assert path.suffix == ".pdf"
+        # PDF files start with %PDF
+        raw = path.read_bytes()
+        assert raw[:5] == b"%PDF-"
+
+    def test_pdf_without_thesis(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_pdf(_make_response(with_thesis=False))
+
+        assert path.exists()
+        raw = path.read_bytes()
+        assert raw[:5] == b"%PDF-"
+
+    def test_pdf_nonzero_size(self, tmp_path: Path) -> None:
+        exporter = ReportExporter(output_dir=tmp_path)
+        path = exporter.save_pdf(_make_response())
+
+        assert path.stat().st_size > 500  # a real PDF with content
+
+    def test_pdf_import_error_without_fpdf2(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify a clear error when fpdf2 is not installed."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _mock_import(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if name == "fpdf":
+                raise ModuleNotFoundError("No module named 'fpdf'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _mock_import)
+
+        exporter = ReportExporter(output_dir=tmp_path)
+        with pytest.raises(RuntimeError, match="fpdf2"):
+            exporter.save_pdf(_make_response())


### PR DESCRIPTION
## Summary

- Add `ReportExporter` class with `save_markdown()`, `save_json()`, and `save_pdf()` methods
- Wire `save_last_report(fmt)` into `ConversationEngine` for format routing
- Add REPL commands (`save md`, `save json`, `save pdf`, and `/save` variants) in CLI
- Register `fpdf2>=2.7.0` as an optional `[pdf]` dependency in `pyproject.toml`

Closes #138

## Files Changed

| File | Change |
|------|--------|
| `src/tracer/conversation/report_exporter.py` | New — `ReportExporter` with three export methods |
| `src/tracer/conversation/engine.py` | Add `save_last_report()` to `ConversationEngine` |
| `src/tracer/conversation/__init__.py` | Re-export `ReportExporter` |
| `src/tracer/cli.py` | Handle `save [md|json|pdf]` in REPL loop |
| `pyproject.toml` | Add `[project.optional-dependencies] pdf` |
| `tests/conversation/test_report_exporter.py` | 10 tests covering all three formats + error case |

## Test plan

- [x] `pytest tests/conversation/test_report_exporter.py` — 10 tests pass
- [x] Full existing test suite (92 tests) still passes
- [ ] Manual: run `qracer repl`, execute a query, then type `save pdf` to verify PDF output

https://claude.ai/code/session_019K3cHD8QRAP9UcGQNonV4z