### PR TITLE
feat: persist SessionDigest on compaction (closes #158)

### DIFF
--- a/qracer/conversation/engine.py
+++ b/qracer/conversation/engine.py
@@ -35,9 +35,10 @@ from qracer.conversation.report_exporter import ReportExporter
 from qracer.conversation.synthesizer import ComparisonSynthesizer, ResponseSynthesizer
 from qracer.data.registry import DataRegistry
 from qracer.llm.registry import LLMRegistry
+from qracer.memory.fact_models import SessionDigest
 from qracer.memory.fact_store import FactStore
 from qracer.memory.memory_searcher import MemorySearcher
-from qracer.memory.session_compactor import SessionCompactor
+from qracer.memory.session_compactor import CompactionResult, SessionCompactor
 from qracer.memory.session_logger import SessionLogger, TurnRecord
 
 logger = logging.getLogger(__name__)
@@ -121,6 +122,13 @@ class ConversationEngine:
         self._turn_counter = 0
         self._last_response: EngineResponse | None = None
         self._config_version = 0
+
+        # Cumulative session metadata used to build a :class:`SessionDigest`
+        # on compaction. Insertion-ordered dicts act as ordered sets so the
+        # digest lists remain deterministic for tests and readability.
+        self._tickers_discussed: dict[str, None] = {}
+        self._intent_types_used: dict[str, None] = {}
+        self._thesis_ids: list[int] = []
 
     def update_registries(
         self,
@@ -229,6 +237,7 @@ class ConversationEngine:
                 result.turn_count,
                 result.output_tokens,
             )
+            self._save_session_digest(result)
         except Exception:
             logger.warning("Session compaction failed", exc_info=True)
 
@@ -321,11 +330,19 @@ class ConversationEngine:
         # 3. Common post-processing: history, logging, compaction.
         self._history.append({"role": "assistant", "content": result.text})
         self._log_turn("assistant", result.text)
-        await self._maybe_compact()
+
+        # Accumulate structured session metadata for the digest written on
+        # compaction. We record this before compaction so the digest reflects
+        # the query that just completed.
+        for ticker in intent.tickers:
+            self._tickers_discussed.setdefault(ticker, None)
+        self._intent_types_used.setdefault(intent.intent_type.value, None)
 
         response = EngineResponse(text=result.text, intent=intent, analysis=result.analysis)
         self._last_response = response
         self._persist_facts(result.analysis)
+
+        await self._maybe_compact()
         return response
 
     def _persist_facts(self, analysis: AnalysisResult) -> None:
@@ -333,6 +350,31 @@ class ConversationEngine:
         if self._fact_store is None or analysis.trade_thesis is None:
             return
         try:
-            self._fact_store.save_thesis(analysis.trade_thesis, self._session_id)
+            thesis_id = self._fact_store.save_thesis(analysis.trade_thesis, self._session_id)
+            self._thesis_ids.append(thesis_id)
         except Exception:
             logger.warning("Failed to persist thesis to fact store", exc_info=True)
+
+    def _save_session_digest(self, result: CompactionResult) -> None:
+        """Write a SessionDigest for the current session to the fact store.
+
+        Called after a successful compaction. The digest captures the
+        cumulative set of tickers and intent types seen this session, plus
+        the thesis ids persisted so far and the free-text summary as
+        ``key_conclusions``. Safe to call repeatedly — :meth:`FactStore.save_digest`
+        upserts by ``session_id``.
+        """
+        if self._fact_store is None:
+            return
+        try:
+            digest = SessionDigest(
+                session_id=self._session_id,
+                tickers_discussed=list(self._tickers_discussed.keys()),
+                intent_types_used=list(self._intent_types_used.keys()),
+                thesis_ids=list(self._thesis_ids),
+                key_conclusions=result.summary,
+                turn_count=result.turn_count,
+            )
+            self._fact_store.save_digest(digest)
+        except Exception:
+            logger.warning("Failed to persist session digest to fact store", exc_info=True)

--- a/qracer/memory/fact_store.py
+++ b/qracer/memory/fact_store.py
@@ -303,9 +303,7 @@ class FactStore:
             ],
         )
 
-    def get_sessions_for_ticker(
-        self, ticker: str, limit: int = 20
-    ) -> list[SessionDigest]:
+    def get_sessions_for_ticker(self, ticker: str, limit: int = 20) -> list[SessionDigest]:
         """Return session digests whose ``tickers_discussed`` contains *ticker*.
 
         Results are ordered by ``created_at`` descending (most recent first).

--- a/qracer/memory/fact_store.py
+++ b/qracer/memory/fact_store.py
@@ -6,6 +6,11 @@ Follows the same connection pattern as ``storage/repositories.py``.
 The store uses its own DuckDB file (``fact_store.duckdb``), separate from
 ``memory_index.duckdb``, so the existing :class:`MemorySearcher` is
 completely unaffected.
+
+SessionDigest persistence complements the free-text Markdown summary
+produced by :class:`SessionCompactor` by preserving structured metadata
+(tickers discussed, intent types used, thesis ids, turn count) that the
+Markdown summary would otherwise lose.
 """
 
 from __future__ import annotations
@@ -17,7 +22,7 @@ from pathlib import Path
 
 import duckdb
 
-from qracer.memory.fact_models import PersistedThesis, ThesisStatus
+from qracer.memory.fact_models import PersistedThesis, SessionDigest, ThesisStatus
 from qracer.models.base import TradeThesis
 
 logger = logging.getLogger(__name__)
@@ -42,6 +47,16 @@ CREATE TABLE IF NOT EXISTS theses (
     created_at        TIMESTAMP NOT NULL,
     updated_at        TIMESTAMP NOT NULL,
     superseded_by     INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS session_digests (
+    session_id        VARCHAR PRIMARY KEY,
+    tickers_discussed VARCHAR[] NOT NULL,
+    intent_types_used VARCHAR[] NOT NULL,
+    thesis_ids        INTEGER[] NOT NULL,
+    key_conclusions   VARCHAR NOT NULL,
+    turn_count        INTEGER NOT NULL,
+    created_at        TIMESTAMP NOT NULL
 );
 """
 
@@ -100,6 +115,19 @@ _SELECT_COLUMNS = (
     "risk_reward_ratio, catalyst, catalyst_date, conviction, summary, "
     "status, session_id, created_at, updated_at, superseded_by"
 )
+
+
+def _row_to_digest(row: tuple) -> SessionDigest:
+    """Convert a DuckDB row tuple to a SessionDigest."""
+    return SessionDigest(
+        session_id=row[0],
+        tickers_discussed=list(row[1]) if row[1] is not None else [],
+        intent_types_used=list(row[2]) if row[2] is not None else [],
+        thesis_ids=list(row[3]) if row[3] is not None else [],
+        key_conclusions=row[4],
+        turn_count=row[5],
+        created_at=row[6],
+    )
 
 
 class FactStore:
@@ -241,6 +269,59 @@ class FactStore:
             "UPDATE theses SET status = ?, superseded_by = ?, updated_at = ? WHERE id = ?",
             [status.value, superseded_by, datetime.now(), thesis_id],
         )
+
+    # ------------------------------------------------------------------
+    # SessionDigest CRUD
+    # ------------------------------------------------------------------
+
+    def save_digest(self, digest: SessionDigest) -> None:
+        """Persist a :class:`SessionDigest` (upsert by ``session_id``).
+
+        Subsequent calls for the same ``session_id`` overwrite the prior
+        digest, so the table always reflects the latest cumulative state
+        of the session (which may be compacted multiple times).
+        """
+        self._conn.execute(
+            "DELETE FROM session_digests WHERE session_id = ?",
+            [digest.session_id],
+        )
+        self._conn.execute(
+            """
+            INSERT INTO session_digests (
+                session_id, tickers_discussed, intent_types_used,
+                thesis_ids, key_conclusions, turn_count, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                digest.session_id,
+                list(digest.tickers_discussed),
+                list(digest.intent_types_used),
+                list(digest.thesis_ids),
+                digest.key_conclusions,
+                digest.turn_count,
+                digest.created_at,
+            ],
+        )
+
+    def get_sessions_for_ticker(
+        self, ticker: str, limit: int = 20
+    ) -> list[SessionDigest]:
+        """Return session digests whose ``tickers_discussed`` contains *ticker*.
+
+        Results are ordered by ``created_at`` descending (most recent first).
+        """
+        rows = self._conn.execute(
+            """
+            SELECT session_id, tickers_discussed, intent_types_used,
+                   thesis_ids, key_conclusions, turn_count, created_at
+            FROM session_digests
+            WHERE list_contains(tickers_discussed, ?)
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            [ticker, limit],
+        ).fetchall()
+        return [_row_to_digest(r) for r in rows]
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -1026,7 +1026,11 @@ class TestSessionDigestPersistence:
             from qracer.llm.providers import CompletionResponse
 
             return CompletionResponse(
-                content=next(intents), input_tokens=1, output_tokens=1, cost=0.0
+                content=next(intents),
+                model="stub",
+                input_tokens=1,
+                output_tokens=1,
+                cost=0.0,
             )
 
         base.get(Role.RESEARCHER).complete = fake_researcher_complete  # type: ignore[method-assign]

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -935,3 +935,200 @@ class TestFactExtraction:
             response = await engine.query("AAPL price")
 
         assert response.text  # Should produce a response without crashing
+
+
+# ---------------------------------------------------------------------------
+# SessionDigest persistence on compaction
+# ---------------------------------------------------------------------------
+
+
+class TestSessionDigestPersistence:
+    async def test_digest_saved_on_compaction(self, tmp_path) -> None:
+        """Compaction should write a SessionDigest capturing the session's
+        cumulative tickers, intent types, thesis ids, and turn count."""
+        from qracer.memory.fact_store import FactStore
+        from qracer.memory.session_compactor import CompactionResult
+        from qracer.memory.session_logger import SessionLogger, TurnRecord
+
+        session_logger = SessionLogger(tmp_path / "sessions" / "sess_digest_01.jsonl")
+        session_logger.append(TurnRecord(turn=1, role="user", content="AAPL price"))
+
+        fact_store = FactStore()
+
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: json.dumps({"intent": "price_check", "tickers": ["AAPL"]}),
+                Role.STRATEGIST: "Response",
+            }
+        )
+        engine = ConversationEngine(
+            llm, DataRegistry(), session_logger=session_logger, fact_store=fact_store
+        )
+
+        # Force compaction path and stub the compactor result.
+        assert engine._compactor is not None
+        engine._compactor.needs_compaction = lambda _: True  # type: ignore[method-assign]
+        engine._compactor.compact = AsyncMock(  # type: ignore[method-assign]
+            return_value=CompactionResult(
+                summary="# Summary\n- AAPL price_check",
+                turn_count=2,
+                input_tokens=10,
+                output_tokens=5,
+                cost=0.0,
+            )
+        )
+
+        with patch("qracer.conversation.handlers.invoke_tools") as mock_invoke:
+            mock_invoke.return_value = [_ok_result("price_event")]
+            await engine.query("AAPL price")
+
+        digests = fact_store.get_sessions_for_ticker("AAPL")
+        assert len(digests) == 1
+        d = digests[0]
+        assert d.session_id == "sess_digest_01"
+        assert d.tickers_discussed == ["AAPL"]
+        assert d.intent_types_used == ["price_check"]
+        assert d.thesis_ids == []  # No TradeThesis produced on quickpath
+        assert d.turn_count == 2
+        assert "AAPL" in d.key_conclusions
+
+        fact_store.close()
+
+    async def test_digest_accumulates_across_queries(self, tmp_path) -> None:
+        """Multiple queries before compaction should produce a digest with
+        the union of their tickers and intent types."""
+        from qracer.memory.fact_store import FactStore
+        from qracer.memory.session_compactor import CompactionResult
+        from qracer.memory.session_logger import SessionLogger
+
+        session_logger = SessionLogger(tmp_path / "sessions" / "sess_digest_02.jsonl")
+        fact_store = FactStore()
+
+        # Two queries, different tickers and intent types. Compaction only
+        # fires on the second call.
+        intents = iter(
+            [
+                json.dumps({"intent": "price_check", "tickers": ["AAPL"]}),
+                json.dumps({"intent": "deep_dive", "tickers": ["MSFT"]}),
+            ]
+        )
+
+        class _StreamLLM:
+            def __init__(self, inner: LLMRegistry) -> None:
+                self._inner = inner
+
+            def __getattr__(self, name):  # type: ignore[no-untyped-def]
+                return getattr(self._inner, name)
+
+        base = _mock_llm_registry({Role.RESEARCHER: "", Role.STRATEGIST: "Resp"})
+
+        async def fake_researcher_complete(req):  # type: ignore[no-untyped-def]
+            from qracer.llm.providers import CompletionResponse
+
+            return CompletionResponse(
+                content=next(intents), input_tokens=1, output_tokens=1, cost=0.0
+            )
+
+        base.get(Role.RESEARCHER).complete = fake_researcher_complete  # type: ignore[method-assign]
+
+        engine = ConversationEngine(
+            base, DataRegistry(), session_logger=session_logger, fact_store=fact_store
+        )
+
+        assert engine._compactor is not None
+        # Compact only on the second query.
+        needs = iter([False, True])
+        engine._compactor.needs_compaction = lambda _: next(needs)  # type: ignore[method-assign]
+        engine._compactor.compact = AsyncMock(  # type: ignore[method-assign]
+            return_value=CompactionResult(
+                summary="summary", turn_count=4, input_tokens=1, output_tokens=1, cost=0.0
+            )
+        )
+
+        with patch("qracer.conversation.handlers.invoke_tools") as mock_invoke:
+            mock_invoke.return_value = [_ok_result("price_event")]
+            await engine.query("AAPL price")
+            await engine.query("MSFT deep dive")
+
+        # Both tickers should be in the digest after the second compaction.
+        aapl = fact_store.get_sessions_for_ticker("AAPL")
+        msft = fact_store.get_sessions_for_ticker("MSFT")
+        assert len(aapl) == 1
+        assert aapl[0].session_id == "sess_digest_02"
+        assert set(aapl[0].tickers_discussed) == {"AAPL", "MSFT"}
+        assert set(aapl[0].intent_types_used) == {"price_check", "deep_dive"}
+        assert len(msft) == 1
+        assert msft[0].session_id == aapl[0].session_id
+
+        fact_store.close()
+
+    async def test_digest_upserts_on_repeated_compactions(self, tmp_path) -> None:
+        """Two compactions in the same session should leave a single digest
+        row reflecting the latest turn_count and summary."""
+        from qracer.memory.fact_store import FactStore
+        from qracer.memory.session_compactor import CompactionResult
+        from qracer.memory.session_logger import SessionLogger
+
+        session_logger = SessionLogger(tmp_path / "sessions" / "sess_digest_03.jsonl")
+        fact_store = FactStore()
+
+        llm = _mock_llm_registry(
+            {
+                Role.RESEARCHER: json.dumps({"intent": "price_check", "tickers": ["AAPL"]}),
+                Role.STRATEGIST: "R",
+            }
+        )
+        engine = ConversationEngine(
+            llm, DataRegistry(), session_logger=session_logger, fact_store=fact_store
+        )
+
+        assert engine._compactor is not None
+        engine._compactor.needs_compaction = lambda _: True  # type: ignore[method-assign]
+        results = iter(
+            [
+                CompactionResult(
+                    summary="first", turn_count=2, input_tokens=1, output_tokens=1, cost=0.0
+                ),
+                CompactionResult(
+                    summary="second", turn_count=4, input_tokens=1, output_tokens=1, cost=0.0
+                ),
+            ]
+        )
+
+        async def fake_compact(_):  # type: ignore[no-untyped-def]
+            return next(results)
+
+        engine._compactor.compact = fake_compact  # type: ignore[method-assign]
+
+        with patch("qracer.conversation.handlers.invoke_tools") as mock_invoke:
+            mock_invoke.return_value = [_ok_result("price_event")]
+            await engine.query("AAPL price 1")
+            await engine.query("AAPL price 2")
+
+        digests = fact_store.get_sessions_for_ticker("AAPL")
+        assert len(digests) == 1
+        assert digests[0].turn_count == 4
+        assert digests[0].key_conclusions == "second"
+
+        fact_store.close()
+
+    async def test_no_digest_without_fact_store(self, tmp_path) -> None:
+        """With no fact_store, compaction should not attempt digest persistence."""
+        from qracer.memory.session_compactor import CompactionResult
+        from qracer.memory.session_logger import SessionLogger, TurnRecord
+
+        session_logger = SessionLogger(tmp_path / "sessions" / "no_store.jsonl")
+        session_logger.append(TurnRecord(turn=1, role="user", content="hi"))
+
+        llm = _mock_llm_registry({Role.RESEARCHER: "", Role.ANALYST: "", Role.STRATEGIST: ""})
+        engine = ConversationEngine(llm, DataRegistry(), session_logger=session_logger)
+        assert engine._compactor is not None
+        engine._compactor.needs_compaction = lambda _: True  # type: ignore[method-assign]
+        engine._compactor.compact = AsyncMock(  # type: ignore[method-assign]
+            return_value=CompactionResult(
+                summary="x", turn_count=1, input_tokens=1, output_tokens=1, cost=0.0
+            )
+        )
+
+        # Should not raise — fact_store is None, digest persistence is skipped.
+        await engine._maybe_compact()

--- a/tests/memory/test_fact_store.py
+++ b/tests/memory/test_fact_store.py
@@ -237,9 +237,7 @@ class TestSessionDigestCRUD:
         assert result[0].key_conclusions == "v2"
         assert result[0].tickers_discussed == ["AAPL", "MSFT"]
 
-    def test_get_sessions_for_ticker_filters_by_membership(
-        self, fact_store: FactStore
-    ) -> None:
+    def test_get_sessions_for_ticker_filters_by_membership(self, fact_store: FactStore) -> None:
         fact_store.save_digest(_make_digest(session_id="s1", tickers_discussed=["AAPL"]))
         fact_store.save_digest(_make_digest(session_id="s2", tickers_discussed=["MSFT"]))
         fact_store.save_digest(_make_digest(session_id="s3", tickers_discussed=["AAPL", "NVDA"]))

--- a/tests/memory/test_fact_store.py
+++ b/tests/memory/test_fact_store.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from qracer.memory.fact_models import ThesisStatus
+from qracer.memory.fact_models import SessionDigest, ThesisStatus
 from qracer.memory.fact_store import FactStore, _parse_catalyst_date
 from qracer.models.base import TradeThesis
 
@@ -170,6 +170,133 @@ class TestCatalystDateParsing:
         upcoming = fact_store.get_upcoming_catalysts(days_ahead=14)
         assert len(upcoming) == 1
         assert upcoming[0].ticker == "NEAR"
+
+
+# ---------------------------------------------------------------------------
+# SessionDigest CRUD
+# ---------------------------------------------------------------------------
+
+
+def _make_digest(
+    session_id: str = "sess_001",
+    tickers_discussed: list[str] | None = None,
+    intent_types_used: list[str] | None = None,
+    thesis_ids: list[int] | None = None,
+    key_conclusions: str = "Bullish on AAPL on AI revenue",
+    turn_count: int = 6,
+    created_at: datetime | None = None,
+) -> SessionDigest:
+    return SessionDigest(
+        session_id=session_id,
+        tickers_discussed=tickers_discussed if tickers_discussed is not None else ["AAPL"],
+        intent_types_used=(
+            intent_types_used if intent_types_used is not None else ["event_analysis"]
+        ),
+        thesis_ids=thesis_ids if thesis_ids is not None else [],
+        key_conclusions=key_conclusions,
+        turn_count=turn_count,
+        created_at=created_at if created_at is not None else datetime.now(),
+    )
+
+
+class TestSessionDigestCRUD:
+    def test_save_and_retrieve_by_ticker(self, fact_store: FactStore) -> None:
+        digest = _make_digest(
+            tickers_discussed=["AAPL", "MSFT"],
+            intent_types_used=["deep_dive", "price_check"],
+            thesis_ids=[1, 2],
+        )
+        fact_store.save_digest(digest)
+
+        result = fact_store.get_sessions_for_ticker("AAPL")
+        assert len(result) == 1
+        d = result[0]
+        assert d.session_id == "sess_001"
+        assert d.tickers_discussed == ["AAPL", "MSFT"]
+        assert d.intent_types_used == ["deep_dive", "price_check"]
+        assert d.thesis_ids == [1, 2]
+        assert d.key_conclusions == "Bullish on AAPL on AI revenue"
+        assert d.turn_count == 6
+
+    def test_upsert_overwrites_existing_session(self, fact_store: FactStore) -> None:
+        """save_digest should replace the prior digest for the same session_id."""
+        fact_store.save_digest(
+            _make_digest(tickers_discussed=["AAPL"], turn_count=4, key_conclusions="v1")
+        )
+        fact_store.save_digest(
+            _make_digest(
+                tickers_discussed=["AAPL", "MSFT"],
+                turn_count=10,
+                key_conclusions="v2",
+            )
+        )
+
+        result = fact_store.get_sessions_for_ticker("AAPL")
+        assert len(result) == 1
+        assert result[0].turn_count == 10
+        assert result[0].key_conclusions == "v2"
+        assert result[0].tickers_discussed == ["AAPL", "MSFT"]
+
+    def test_get_sessions_for_ticker_filters_by_membership(
+        self, fact_store: FactStore
+    ) -> None:
+        fact_store.save_digest(_make_digest(session_id="s1", tickers_discussed=["AAPL"]))
+        fact_store.save_digest(_make_digest(session_id="s2", tickers_discussed=["MSFT"]))
+        fact_store.save_digest(_make_digest(session_id="s3", tickers_discussed=["AAPL", "NVDA"]))
+
+        aapl_sessions = {d.session_id for d in fact_store.get_sessions_for_ticker("AAPL")}
+        assert aapl_sessions == {"s1", "s3"}
+
+        msft_sessions = {d.session_id for d in fact_store.get_sessions_for_ticker("MSFT")}
+        assert msft_sessions == {"s2"}
+
+    def test_get_sessions_for_ticker_ordered_desc(self, fact_store: FactStore) -> None:
+        older = datetime(2026, 1, 1, 10, 0, 0)
+        newer = datetime(2026, 2, 1, 10, 0, 0)
+        fact_store.save_digest(
+            _make_digest(session_id="older", tickers_discussed=["AAPL"], created_at=older)
+        )
+        fact_store.save_digest(
+            _make_digest(session_id="newer", tickers_discussed=["AAPL"], created_at=newer)
+        )
+
+        result = fact_store.get_sessions_for_ticker("AAPL")
+        assert [d.session_id for d in result] == ["newer", "older"]
+
+    def test_get_sessions_for_ticker_respects_limit(self, fact_store: FactStore) -> None:
+        for i in range(5):
+            fact_store.save_digest(
+                _make_digest(
+                    session_id=f"s{i}",
+                    tickers_discussed=["AAPL"],
+                    created_at=datetime(2026, 1, 1, 10, i, 0),
+                )
+            )
+
+        assert len(fact_store.get_sessions_for_ticker("AAPL", limit=2)) == 2
+
+    def test_get_sessions_for_ticker_empty(self, fact_store: FactStore) -> None:
+        assert fact_store.get_sessions_for_ticker("AAPL") == []
+
+    def test_save_digest_with_empty_lists(self, fact_store: FactStore) -> None:
+        """Digests for sessions with no tickers/theses persist with empty arrays."""
+        fact_store.save_digest(
+            _make_digest(
+                session_id="empty",
+                tickers_discussed=[],
+                intent_types_used=[],
+                thesis_ids=[],
+            )
+        )
+        # Can't look it up by ticker (none discussed) — query table directly.
+        rows = fact_store.connection.execute(
+            "SELECT tickers_discussed, intent_types_used, thesis_ids "
+            "FROM session_digests WHERE session_id = 'empty'"
+        ).fetchone()
+        assert rows is not None
+        assert list(rows[0]) == []
+        assert list(rows[1]) == []
+        assert list(rows[2]) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #158.

Phase 2 companion to the FactStore work from #156: the free-text Markdown summary produced by `SessionCompactor` is now accompanied by a structured `SessionDigest` row so cross-session ticker lookups no longer depend on text search hits.

### What changed

- **`qracer/memory/fact_store.py`** — new `session_digests` table (`tickers_discussed VARCHAR[]`, `intent_types_used VARCHAR[]`, `thesis_ids INTEGER[]`, `key_conclusions`, `turn_count`, `created_at`). `save_digest()` upserts by `session_id` (delete-then-insert) so repeated compactions within a session leave a single row reflecting the latest cumulative state. `get_sessions_for_ticker()` uses `list_contains(tickers_discussed, ?)` ordered by `created_at DESC` with a configurable `limit` (default 20).
- **`qracer/conversation/engine.py`** — accumulates `tickers_discussed` and `intent_types_used` across queries using insertion-ordered dicts (deterministic for tests), records `thesis_ids` from `_persist_facts`, and calls `_save_session_digest` after each successful compaction. Digest persistence is wrapped in its own try/except so a fact-store failure never breaks the query loop.
- **Order-of-operations:** moved `_persist_facts` ahead of `_maybe_compact` so the digest can reference the thesis id that was just saved for this turn.

### Non-goals

- No schema change for the existing `theses` or `findings` tables.
- No UI surface yet for the new `get_sessions_for_ticker` lookup — that can hang off the next memory-search upgrade (#159).

## Test plan

- `uv run pytest tests/memory/test_fact_store.py tests/conversation/test_engine.py` — **97 passed** (7 new `TestSessionDigestCRUD` cases + 4 new `TestSessionDigestPersistence` engine cases).
- `uv run pytest` full suite — **789 passed, 14 skipped**.
- `uv run ruff check qracer/memory/fact_store.py qracer/conversation/engine.py tests/...` — clean.
- `uv run pyright qracer/memory/fact_store.py qracer/conversation/engine.py` — 0 errors.

### New tests cover

- Save + round-trip retrieval by ticker (array-membership filter works).
- Upsert semantics — second save for the same `session_id` replaces the first.
- Multi-ticker membership (`AAPL`-only session vs. `AAPL+NVDA` session).
- Ordering by `created_at DESC` and `limit` honored.
- Empty `tickers_discussed`/`thesis_ids` survive round-trip.
- Engine writes digest on compaction with correct `tickers_discussed`, `intent_types_used`, `turn_count`, `key_conclusions`.
- Multi-query accumulation: two queries with different tickers/intents produce a digest containing the union.
- Repeated compactions upsert a single row with the latest turn_count/summary.
- No `fact_store` configured → no crash, no-op.
