### PR TITLE
feat: FactStore-first memory_search for ticker-scoped queries (closes #159)

### DIFF
--- a/qracer/conversation/dispatcher.py
+++ b/qracer/conversation/dispatcher.py
@@ -6,6 +6,7 @@ import asyncio
 
 from qracer.conversation.intent import INTENT_TOOL_MAP, Intent
 from qracer.data.registry import DataRegistry
+from qracer.memory.fact_store import FactStore
 from qracer.memory.memory_searcher import MemorySearcher
 from qracer.models import ToolResult
 from qracer.tools import pipeline
@@ -37,6 +38,7 @@ async def invoke_tool(
     registry: DataRegistry,
     *,
     memory_searcher: MemorySearcher | None = None,
+    fact_store: FactStore | None = None,
 ) -> ToolResult:
     """Invoke a single pipeline tool based on the intent context."""
     tickers = intent.tickers
@@ -54,7 +56,12 @@ async def invoke_tool(
     if tool_name == "macro":
         return await pipeline.macro(intent.raw_query, registry)
     if tool_name == "memory_search":
-        return await pipeline.memory_search(intent.raw_query, searcher=memory_searcher)
+        return await pipeline.memory_search(
+            intent.raw_query,
+            searcher=memory_searcher,
+            fact_store=fact_store,
+            tickers=tickers,
+        )
 
     return ToolResult(
         tool=tool_name,
@@ -71,11 +78,19 @@ async def invoke_tools(
     registry: DataRegistry,
     *,
     memory_searcher: MemorySearcher | None = None,
+    fact_store: FactStore | None = None,
 ) -> list[ToolResult]:
     """Invoke multiple pipeline tools concurrently."""
     if not tool_names:
         return []
     coros = [
-        invoke_tool(name, intent, registry, memory_searcher=memory_searcher) for name in tool_names
+        invoke_tool(
+            name,
+            intent,
+            registry,
+            memory_searcher=memory_searcher,
+            fact_store=fact_store,
+        )
+        for name in tool_names
     ]
     return list(await asyncio.gather(*coros))

--- a/qracer/conversation/engine.py
+++ b/qracer/conversation/engine.py
@@ -100,7 +100,10 @@ class ConversationEngine:
             data_registry, memory_searcher, language=language, fact_store=fact_store
         )
         self._comparison_handler = ComparisonHandler(
-            data_registry, comparison_synthesizer, memory_searcher
+            data_registry,
+            comparison_synthesizer,
+            memory_searcher,
+            fact_store=fact_store,
         )
         self._standard_handler = StandardHandler(
             data_registry,
@@ -156,7 +159,10 @@ class ConversationEngine:
             fact_store=self._fact_store,
         )
         self._comparison_handler = ComparisonHandler(
-            data_registry, comparison_synthesizer, self._memory_searcher
+            data_registry,
+            comparison_synthesizer,
+            self._memory_searcher,
+            fact_store=self._fact_store,
         )
         self._standard_handler = StandardHandler(
             data_registry,

--- a/qracer/conversation/handlers.py
+++ b/qracer/conversation/handlers.py
@@ -103,7 +103,11 @@ class QuickPathHandler:
 
     async def handle(self, intent: Intent) -> HandlerResult:
         results = await invoke_tools(
-            intent.tools, intent, self._data, memory_searcher=self._memory_searcher
+            intent.tools,
+            intent,
+            self._data,
+            memory_searcher=self._memory_searcher,
+            fact_store=self._fact_store,
         )
         text = format_quickpath(intent, results, language=self._language)
 
@@ -125,10 +129,13 @@ class ComparisonHandler:
         data_registry: DataRegistry,
         synthesizer: ComparisonSynthesizer,
         memory_searcher: MemorySearcher | None = None,
+        *,
+        fact_store: FactStore | None = None,
     ) -> None:
         self._data = data_registry
         self._synthesizer = synthesizer
         self._memory_searcher = memory_searcher
+        self._fact_store = fact_store
 
     async def handle(self, intent: Intent) -> HandlerResult:
         single_intents = [
@@ -142,7 +149,13 @@ class ComparisonHandler:
         ]
         gathered = await asyncio.gather(
             *[
-                invoke_tools(si.tools, si, self._data, memory_searcher=self._memory_searcher)
+                invoke_tools(
+                    si.tools,
+                    si,
+                    self._data,
+                    memory_searcher=self._memory_searcher,
+                    fact_store=self._fact_store,
+                )
                 for si in single_intents
             ]
         )
@@ -178,7 +191,11 @@ class StandardHandler:
     async def handle(self, intent: Intent) -> HandlerResult:
         # Invoke initial pipeline tools.
         initial_results = await invoke_tools(
-            intent.tools, intent, self._data, memory_searcher=self._memory_searcher
+            intent.tools,
+            intent,
+            self._data,
+            memory_searcher=self._memory_searcher,
+            fact_store=self._fact_store,
         )
 
         # Inject open theses from fact store as prior evidence.

--- a/qracer/tools/pipeline.py
+++ b/qracer/tools/pipeline.py
@@ -23,6 +23,7 @@ from qracer.data.providers import (
 from qracer.data.registry import DataRegistry
 from qracer.llm.providers import CompletionRequest, Message, Role
 from qracer.llm.registry import LLMRegistry
+from qracer.memory.fact_store import FactStore
 from qracer.memory.memory_searcher import MemorySearcher
 from qracer.models import ToolResult, TradeThesis
 
@@ -445,23 +446,115 @@ async def risk_check(
         )
 
 
+def _structured_lookup(
+    fact_store: FactStore, tickers: list[str]
+) -> dict[str, Any]:
+    """Fetch structured theses and findings for *tickers* from the fact store.
+
+    Findings lookup is gated on ``hasattr`` so the pipeline stays compatible
+    with builds of :class:`FactStore` that do not yet expose ``get_findings``
+    (see issue #157 / Phase 2).  Any store-side exception is swallowed — the
+    caller will then fall back to free-text search.
+    """
+    theses: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+
+    try:
+        open_theses = fact_store.get_open_theses(tickers)
+    except Exception:
+        logger.debug("fact_store.get_open_theses failed", exc_info=True)
+        open_theses = []
+
+    for t in open_theses:
+        theses.append(
+            {
+                "id": t.id,
+                "ticker": t.ticker,
+                "entry_zone": [t.entry_zone_low, t.entry_zone_high],
+                "target_price": t.target_price,
+                "stop_loss": t.stop_loss,
+                "risk_reward_ratio": t.risk_reward_ratio,
+                "catalyst": t.catalyst,
+                "catalyst_date": t.catalyst_date,
+                "conviction": t.conviction,
+                "summary": t.summary,
+                "status": t.status.value,
+                "session_id": t.session_id,
+            }
+        )
+
+    get_findings = getattr(fact_store, "get_findings", None)
+    if callable(get_findings):
+        for ticker in tickers:
+            try:
+                raw_findings: Any = get_findings(ticker)
+                ticker_findings: list[Any] = list(raw_findings or [])
+            except Exception:
+                logger.debug(
+                    "fact_store.get_findings failed for %s", ticker, exc_info=True
+                )
+                continue
+            for f in ticker_findings:
+                findings.append(
+                    {
+                        "entity": getattr(f, "entity", ticker),
+                        "statement": getattr(f, "statement", ""),
+                        "confidence": getattr(f, "confidence", 0.0),
+                        "source_tool": getattr(f, "source_tool", ""),
+                        "session_id": getattr(f, "session_id", ""),
+                        "event_date": getattr(f, "event_date", None),
+                    }
+                )
+
+    return {"theses": theses, "findings": findings}
+
+
 async def memory_search(
-    query: str, searcher: MemorySearcher | None = None, **kwargs: object
+    query: str,
+    searcher: MemorySearcher | None = None,
+    *,
+    fact_store: FactStore | None = None,
+    tickers: list[str] | None = None,
+    **kwargs: object,
 ) -> ToolResult:
     """Search past analyses stored in session memory.
 
-    If a MemorySearcher instance is provided, performs a real FTS search.
-    Otherwise returns empty results (graceful degradation).
+    Two-stage retrieval:
+
+    1. When a :class:`FactStore` is available and *tickers* is non-empty,
+       run a structured lookup first (open theses + findings).  If any
+       structured records are found they are returned directly — this is the
+       deterministic path for ticker-scoped queries ("how's my AAPL thesis
+       going?").
+    2. Otherwise fall back to the existing :class:`MemorySearcher` free-text
+       search over compacted session summaries.
+
+    If neither backend is available (nor produces results), an empty
+    ``results`` list is returned so the caller degrades gracefully.
     """
 
     async def _fetch() -> dict[str, Any]:
+        # Stage 1: structured FactStore lookup.
+        if fact_store is not None and tickers:
+            structured = _structured_lookup(fact_store, tickers)
+            if structured["theses"] or structured["findings"]:
+                return {
+                    "query": query,
+                    "source": "fact_store",
+                    "results": [],
+                    "theses": structured["theses"],
+                    "findings": structured["findings"],
+                }
+
+        # Stage 2: free-text fallback.
         if searcher is None:
-            return {"query": query, "results": []}
+            return {"query": query, "source": "none", "results": []}
 
         try:
             results = searcher.search(query, limit=5)
             return {
                 "query": query,
+                "source": "memory_searcher",
                 "results": [
                     {
                         "session_id": r.session_id,
@@ -473,6 +566,6 @@ async def memory_search(
             }
         except Exception:
             logger.debug("memory_search query failed for '%s'", query, exc_info=True)
-            return {"query": query, "results": []}
+            return {"query": query, "source": "none", "results": []}
 
     return await _run_tool("memory_search", "SessionMemory", _fetch, label=query, stale_check=False)

--- a/qracer/tools/pipeline.py
+++ b/qracer/tools/pipeline.py
@@ -446,9 +446,7 @@ async def risk_check(
         )
 
 
-def _structured_lookup(
-    fact_store: FactStore, tickers: list[str]
-) -> dict[str, Any]:
+def _structured_lookup(fact_store: FactStore, tickers: list[str]) -> dict[str, Any]:
     """Fetch structured theses and findings for *tickers* from the fact store.
 
     Findings lookup is gated on ``hasattr`` so the pipeline stays compatible
@@ -490,9 +488,7 @@ def _structured_lookup(
                 raw_findings: Any = get_findings(ticker)
                 ticker_findings: list[Any] = list(raw_findings or [])
             except Exception:
-                logger.debug(
-                    "fact_store.get_findings failed for %s", ticker, exc_info=True
-                )
+                logger.debug("fact_store.get_findings failed for %s", ticker, exc_info=True)
                 continue
             for f in ticker_findings:
                 findings.append(

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -75,16 +75,12 @@ class TestInvokeTool:
         """Dispatcher should pass fact_store + intent.tickers into memory_search."""
         from qracer.memory.fact_store import FactStore
 
-        intent = Intent(
-            IntentType.FOLLOW_UP, tickers=["AAPL"], raw_query="how's AAPL doing?"
-        )
+        intent = Intent(IntentType.FOLLOW_UP, tickers=["AAPL"], raw_query="how's AAPL doing?")
         registry = DataRegistry()
         store = FactStore()
         try:
             with patch("qracer.conversation.dispatcher.pipeline") as mock_pipeline:
-                mock_pipeline.memory_search = AsyncMock(
-                    return_value=_ok_result("memory_search")
-                )
+                mock_pipeline.memory_search = AsyncMock(return_value=_ok_result("memory_search"))
                 await invoke_tool("memory_search", intent, registry, fact_store=store)
                 mock_pipeline.memory_search.assert_called_once_with(
                     "how's AAPL doing?",

--- a/tests/conversation/test_engine.py
+++ b/tests/conversation/test_engine.py
@@ -64,7 +64,36 @@ class TestInvokeTool:
         with patch("qracer.conversation.dispatcher.pipeline") as mock_pipeline:
             mock_pipeline.memory_search = AsyncMock(return_value=_ok_result("memory_search"))
             await invoke_tool("memory_search", intent, registry)
-            mock_pipeline.memory_search.assert_called_once_with("what about before?", searcher=None)
+            mock_pipeline.memory_search.assert_called_once_with(
+                "what about before?",
+                searcher=None,
+                fact_store=None,
+                tickers=[],
+            )
+
+    async def test_memory_search_forwards_fact_store_and_tickers(self) -> None:
+        """Dispatcher should pass fact_store + intent.tickers into memory_search."""
+        from qracer.memory.fact_store import FactStore
+
+        intent = Intent(
+            IntentType.FOLLOW_UP, tickers=["AAPL"], raw_query="how's AAPL doing?"
+        )
+        registry = DataRegistry()
+        store = FactStore()
+        try:
+            with patch("qracer.conversation.dispatcher.pipeline") as mock_pipeline:
+                mock_pipeline.memory_search = AsyncMock(
+                    return_value=_ok_result("memory_search")
+                )
+                await invoke_tool("memory_search", intent, registry, fact_store=store)
+                mock_pipeline.memory_search.assert_called_once_with(
+                    "how's AAPL doing?",
+                    searcher=None,
+                    fact_store=store,
+                    tickers=["AAPL"],
+                )
+        finally:
+            store.close()
 
     async def test_tool_without_tickers_returns_failure(self) -> None:
         intent = Intent(IntentType.EVENT_ANALYSIS, tickers=[], raw_query="test")

--- a/tests/tools/test_pipeline.py
+++ b/tests/tools/test_pipeline.py
@@ -226,6 +226,147 @@ class TestMemorySearch:
         assert result.tool == "memory_search"
         assert result.data["results"] == []
 
+    async def test_fact_store_ticker_lookup_returns_theses(self) -> None:
+        """Structured theses from FactStore short-circuit the free-text search."""
+        from qracer.memory.fact_store import FactStore
+        from qracer.models import TradeThesis
+
+        store = FactStore()
+        try:
+            thesis = TradeThesis(
+                ticker="AAPL",
+                entry_zone=(175.0, 180.0),
+                target_price=200.0,
+                stop_loss=165.0,
+                risk_reward_ratio=2.5,
+                catalyst="AI revenue",
+                catalyst_date="Q2 2026",
+                conviction=8,
+                summary="Long AAPL.",
+            )
+            store.save_thesis(thesis, session_id="sess_001")
+
+            result = await memory_search(
+                "how's my AAPL thesis?",
+                searcher=None,
+                fact_store=store,
+                tickers=["AAPL"],
+            )
+
+            assert result.success is True
+            assert result.data["source"] == "fact_store"
+            assert len(result.data["theses"]) == 1
+            assert result.data["theses"][0]["ticker"] == "AAPL"
+            assert result.data["theses"][0]["conviction"] == 8
+            assert result.data["results"] == []
+        finally:
+            store.close()
+
+    async def test_fact_store_empty_falls_back_to_searcher(self) -> None:
+        """When FactStore has no ticker hits, free-text search runs instead."""
+        from unittest.mock import MagicMock
+
+        from qracer.memory.fact_store import FactStore
+        from qracer.memory.memory_searcher import SearchResult
+
+        store = FactStore()
+        searcher = MagicMock()
+        searcher.search.return_value = [
+            SearchResult(
+                session_id="sess_42",
+                summary="Prior AAPL analysis notes.",
+                score=1.5,
+                indexed_at=datetime(2026, 1, 1),
+            )
+        ]
+        try:
+            result = await memory_search(
+                "AAPL earnings",
+                searcher=searcher,
+                fact_store=store,
+                tickers=["AAPL"],
+            )
+
+            assert result.success is True
+            assert result.data["source"] == "memory_searcher"
+            assert result.data["results"][0]["session_id"] == "sess_42"
+            searcher.search.assert_called_once_with("AAPL earnings", limit=5)
+        finally:
+            store.close()
+
+    async def test_no_tickers_uses_searcher(self) -> None:
+        """Without tickers the FactStore path is skipped entirely."""
+        from unittest.mock import MagicMock
+
+        from qracer.memory.fact_store import FactStore
+
+        store = FactStore()
+        searcher = MagicMock()
+        searcher.search.return_value = []
+        try:
+            result = await memory_search(
+                "some macro query",
+                searcher=searcher,
+                fact_store=store,
+                tickers=[],
+            )
+
+            assert result.data["source"] == "memory_searcher"
+            searcher.search.assert_called_once()
+        finally:
+            store.close()
+
+    async def test_fact_store_exception_falls_back(self) -> None:
+        """A broken FactStore does not bubble up — we fall back to the searcher."""
+        from unittest.mock import MagicMock
+
+        broken_store = MagicMock()
+        broken_store.get_open_theses.side_effect = RuntimeError("db gone")
+
+        searcher = MagicMock()
+        searcher.search.return_value = []
+
+        result = await memory_search(
+            "AAPL",
+            searcher=searcher,
+            fact_store=broken_store,
+            tickers=["AAPL"],
+        )
+
+        assert result.success is True
+        assert result.data["source"] == "memory_searcher"
+        searcher.search.assert_called_once()
+
+    async def test_fact_store_findings_included_when_available(self) -> None:
+        """If the FactStore exposes get_findings, findings are included."""
+        from unittest.mock import MagicMock
+
+        from qracer.memory.fact_models import Finding
+
+        store = MagicMock()
+        store.get_open_theses.return_value = []
+        store.get_findings.return_value = [
+            Finding(
+                id=1,
+                entity="AAPL",
+                statement="P/E ratio 29",
+                confidence=0.9,
+                source_tool="fundamentals",
+                session_id="sess_001",
+            )
+        ]
+
+        result = await memory_search(
+            "AAPL valuation",
+            searcher=None,
+            fact_store=store,
+            tickers=["AAPL"],
+        )
+
+        assert result.data["source"] == "fact_store"
+        assert len(result.data["findings"]) == 1
+        assert result.data["findings"][0]["statement"] == "P/E ratio 29"
+
 
 class TestConfigure:
     def test_configure_lookback_days(self) -> None:


### PR DESCRIPTION
## Summary

Closes #159.

`pipeline.memory_search()` previously passed the raw user query directly to BM25/vector search — it had no awareness of `Intent.tickers` or the `FactStore`. Ticker-scoped questions like *"how's my AAPL thesis going?"* relied on keyword overlap with past Markdown summaries instead of a direct lookup against the structured thesis table.

This PR turns `memory_search` into the two-stage retrieval described in the issue:

1. **Structured first.** When a `FactStore` is configured and the intent carries tickers, run `get_open_theses(tickers)` (and `get_findings(ticker)` when the store exposes it — gated on `hasattr` so we're forward-compatible with #157 / PR #166). If any structured records come back, return them directly as the sole result — no free-text search is performed.
2. **Free-text fallback.** Otherwise fall back to the existing `MemorySearcher.search(query)` path. If there's no searcher either, return an empty `results` list — same graceful-degradation behavior as before.

## What changed

- **`qracer/tools/pipeline.py`**
  - `memory_search(query, searcher=None, *, fact_store=None, tickers=None, **kwargs)` — new kwargs; old keyword-only callers are still compatible.
  - New `_structured_lookup(fact_store, tickers)` helper builds the theses/findings payload and swallows store-side exceptions so a broken `FactStore` always falls back to free-text search.
  - Result shape now carries a `"source"` field (`"fact_store"`, `"memory_searcher"`, or `"none"`) so analysts / downstream formatters can tell which path won.

- **`qracer/conversation/dispatcher.py`**
  - `invoke_tool` / `invoke_tools` accept an optional `fact_store` kwarg and forward it into `pipeline.memory_search` alongside `intent.tickers`.

- **`qracer/conversation/handlers.py`**
  - `QuickPathHandler`, `StandardHandler`: pass their existing `self._fact_store` into `invoke_tools`.
  - `ComparisonHandler`: gains an optional `fact_store` constructor arg and threads it through the per-ticker `invoke_tools` fan-out.

- **`qracer/conversation/engine.py`**
  - Wires `fact_store=fact_store` into both `ComparisonHandler` constructions (init + `update_registries` hot-swap).

## Scope mapping (#159)

| Scope item | Status |
|---|---|
| `pipeline.memory_search()` accepts `fact_store` | ✅ |
| Structured lookup first when tickers present | ✅ `_structured_lookup` runs before free-text |
| Return structured results directly when sufficient | ✅ short-circuits when `theses` or `findings` non-empty |
| Fall back to `MemorySearcher.search(query)` otherwise | ✅ stage 2 |
| Thread `fact_store` through dispatcher → pipeline | ✅ `invoke_tool`/`invoke_tools` kwargs |
| Tests updated | ✅ see below |

## Test plan

- `uv run pytest tests/tools/test_pipeline.py tests/conversation/test_engine.py` — **63 passed** (5 new `TestMemorySearch` cases + updated dispatcher assertion + new `test_memory_search_forwards_fact_store_and_tickers`).
- `uv run pytest` full suite — **784 passed, 14 skipped**.
- `uv run ruff check` on changed files — clean.
- `uv run pyright` on changed files — 0 errors.

### New tests cover

- Structured theses from `FactStore` short-circuit the free-text search (`source=fact_store`, theses populated, `results` empty).
- Empty structured hit → falls back to `MemorySearcher.search()` (`source=memory_searcher`, searcher called exactly once).
- No tickers → skip FactStore path entirely.
- `FactStore.get_open_theses` raises → fall back to free-text instead of bubbling.
- When the store exposes `get_findings`, findings are included in the payload.
- Dispatcher passes `fact_store` + `intent.tickers` into `pipeline.memory_search`.

### Manual verification

```python
from qracer.memory.fact_store import FactStore
from qracer.models import TradeThesis
from qracer.tools.pipeline import memory_search

store = FactStore()
store.save_thesis(
    TradeThesis(
        ticker="AAPL", entry_zone=(175, 180), target_price=200, stop_loss=165,
        risk_reward_ratio=2.5, catalyst="AI revenue", catalyst_date="Q2 2026",
        conviction=8, summary="Long AAPL.",
    ),
    session_id="sess_001",
)
result = await memory_search("how's my AAPL thesis?", fact_store=store, tickers=["AAPL"])
# result.data["source"] == "fact_store"
# result.data["theses"][0]["ticker"] == "AAPL"
```
