### PR TITLE
feat: schema-driven settings UX (terminal + web) with a safe config writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ qracer install
 qracer repl
 ```
 
+### Configuration
+
+Settings live in `~/.qracer/` and can be edited from the terminal or the web dashboard —
+both share one schema and a comment-preserving writer, so nothing hand-edited is lost:
+
+```bash
+qracer config                       # list all settings, grouped, with current values
+qracer config set briefing.schedule "0 9 * * *"
+qracer config providers             # enable/disable providers and set API keys, interactively
+```
+
+Or open the web dashboard's **Settings** tab (`qracer web`, localhost only) to toggle
+providers, enter API keys (masked), and change app/briefing/portfolio settings from a form.
+
 ## Architecture
 
 ```text
@@ -60,7 +74,7 @@ qracer/
 ├── tools/          # Pipeline tool wrappers (ToolResult)
 ├── config/         # .qracer/ config loading and pydantic models
 ├── notifications/  # Telegram send + inbound poller
-├── web/            # FastAPI API + NiceGUI custom-agent config UI
+├── web/            # FastAPI API + NiceGUI dashboard (status + editable Agents/Settings)
 ├── models/         # Domain models (ToolResult, TradeThesis)
 ├── agents/         # Legacy role classes (not wired into the live pipeline)
 ├── server.py       # `qracer serve` daemon loop

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,18 @@ Config resolves in order (first found wins): `QRACER_CONFIG_DIR` → `./.qracer/
 Loader: `config/loader.py` (lazy singleton, mtime hot-reload). Models:
 `config/models.py` (pydantic).
 
+**Editing config** is schema-driven, so both front-ends stay in sync:
+- `config/settings_schema.py` declares each editable setting once (`Setting` + the
+  provider rows from `provider_settings()`). Add a setting here and it appears in
+  both the CLI and the web form.
+- `config/writer.py` is the single write path — `tomlkit` round-trip edits that
+  preserve comments, formatting, and nested tables (`[briefing]`, `[providers.*]`,
+  `[limits]`), plus a `credentials.env` upsert. Writes target `QRACER_CONFIG_DIR`
+  if set, else `~/.qracer/`.
+- Front-ends: `qracer config` (`get`/`set`/`providers` + a grouped listing) and the
+  web dashboard **Settings** tab (`web/settings_ui.py`). API keys are masked and
+  write-only. `qracer install` builds on the same writer.
+
 ## Storage & State
 
 | Path | Backing | Written by |
@@ -108,7 +120,7 @@ See [memory-system.md](memory-system.md) for the session-memory tiers.
 | Tools | `tools/pipeline.py` | uniform `ToolResult`-returning tool wrappers |
 | Daemon | `server.py`, `task_executor.py`, `alert_monitor.py`, `autonomous.py` | `qracer serve` ([serve.md](serve.md), [schedule.md](schedule.md)) |
 | Custom agents | `agents_store.py`, `agent_runner.py`, `agent_monitor.py` | prompt-defined autonomous agents ([custom-agents.md](custom-agents.md)) |
-| Web | `web/` | FastAPI API + NiceGUI agent-config UI |
+| Web | `web/` | FastAPI API + NiceGUI dashboard (read-only status + editable Agents & Settings) |
 | Notifications | `notifications/` | Telegram send + inbound poller |
 
 ## Roadmap — grounded investor harness

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "tomli>=2.0.0; python_version < '3.11'",
   "textual>=0.70.0",
   "croniter>=2.0.0",
+  "tomlkit>=0.13.0",
 ]
 
 [project.optional-dependencies]

--- a/qracer/cli.py
+++ b/qracer/cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import re
 import shutil
 import sys
 from pathlib import Path
@@ -13,6 +12,7 @@ from pathlib import Path
 import click
 
 from qracer.bootstrap import build_registries
+from qracer.config import writer
 from qracer.config.loader import (
     _load_toml,
     _user_dir,
@@ -73,34 +73,6 @@ def _collect_llm_choices() -> list[tuple[str, str, str | None]]:
             env: str | None = cfg.get("api_key_env")
             result.append((name, label, env))
     return result
-
-
-def _update_provider_selection(
-    providers_path: Path,
-    chosen: str,
-    all_llm: list[tuple[str, str, str | None]],
-) -> None:
-    """Enable the chosen LLM provider and disable others in providers.toml."""
-    if not providers_path.exists():
-        return
-    text = providers_path.read_text(encoding="utf-8")
-    for name, _, _ in all_llm:
-        enable = "true" if name == chosen else "false"
-        pattern = rf"(\[providers\.{re.escape(name)}\][^\[]*?)enabled\s*=\s*(true|false)"
-        text = re.sub(pattern, rf"\1enabled = {enable}", text)
-    providers_path.write_text(text, encoding="utf-8")
-
-
-def _update_config_llm(config_path: Path, provider: str, model: str | None = None) -> None:
-    """Persist the active LLM provider (and model, if given) into config.toml."""
-    if not config_path.exists():
-        return
-    original = config_path.read_text(encoding="utf-8")
-    text = re.sub(r"(?m)^\s*llm_provider\s*=.*$", f'llm_provider = "{provider}"', original, count=1)
-    if model:
-        text = re.sub(r"(?m)^\s*llm_model\s*=.*$", f'llm_model = "{model}"', text, count=1)
-    if text != original:
-        config_path.write_text(text, encoding="utf-8")
 
 
 def _select_openrouter_model() -> str:
@@ -166,14 +138,18 @@ def install() -> None:
     # 1. Create directory
     home_dir.mkdir(parents=True, exist_ok=True)
 
-    # 2. Copy default config files
+    # 2. Copy default config files (remembering which we actually created, so the
+    #    wizard's choices below only touch files we own — never an existing setup).
+    created: dict[str, bool] = {}
     for name in ("config.toml", "providers.toml", "portfolio.toml"):
         src = SCHEMA_DIR / name
         dest = home_dir / name
         if dest.exists():
+            created[name] = False
             click.echo(f"  {name} already exists, skipping.")
         else:
             shutil.copy2(src, dest)
+            created[name] = True
             click.echo(f"  Created {name}")
 
     # 3. LLM provider selection
@@ -200,26 +176,28 @@ def install() -> None:
     # 5. Prompt for portfolio currency
     currency = click.prompt("\n  Portfolio currency", default="USD").strip()
 
-    # 6. Write credentials.env
-    creds_path = home_dir / "credentials.env"
-    lines = [f"{k}={v}" for k, v in creds.items()]
-    creds_path.write_text("\n".join(lines) + "\n" if lines else "")
+    # 6. Write credentials.env (structured upsert, preserves any existing keys).
+    if chosen_env and creds.get(chosen_env):
+        writer.set_credential(chosen_env, creds[chosen_env], config_dir=home_dir)
+    (home_dir / "credentials.env").touch(exist_ok=True)  # always present, even if empty
 
-    # 7. Enable chosen LLM provider in providers.toml
-    _update_provider_selection(home_dir / "providers.toml", chosen_name, llm_choices)
+    # 7. Enable the chosen LLM provider (disable the others) — only in a providers.toml
+    #    we just created, so re-running install never disturbs an existing setup.
+    if created["providers.toml"]:
+        for name, _, _ in llm_choices:
+            writer.set_provider_field(name, "enabled", name == chosen_name, config_dir=home_dir)
 
-    # 7b. Persist provider (+ OpenRouter model) choice to config.toml
-    _update_config_llm(home_dir / "config.toml", chosen_name, openrouter_model)
+    # 7b. Persist provider (+ OpenRouter model) choice to a freshly-created config.toml.
+    if created["config.toml"]:
+        writer.set_config_value("llm_provider", chosen_name, config_dir=home_dir)
+        if openrouter_model:
+            writer.set_config_value("llm_model", openrouter_model, config_dir=home_dir)
     if openrouter_model:
         click.echo(f"  Model set to {openrouter_model}")
 
-    # 8. Update portfolio currency if non-default
-    if currency != "USD":
-        portfolio_path = home_dir / "portfolio.toml"
-        if portfolio_path.exists():
-            text = portfolio_path.read_text(encoding="utf-8")
-            text = text.replace('currency = "USD"', f'currency = "{currency}"')
-            portfolio_path.write_text(text, encoding="utf-8")
+    # 8. Update portfolio currency if non-default (only in a portfolio.toml we created).
+    if created["portfolio.toml"] and currency and currency != "USD":
+        writer.set_portfolio_value("currency", currency, config_dir=home_dir)
 
     click.echo(f"\n✓ Setup complete! {chosen_label} enabled as LLM provider.")
 
@@ -331,52 +309,116 @@ def status() -> None:
 # ---------------------------------------------------------------------------
 
 
-@main.command("config")
-@click.option("--set", "set_value", default=None, help="Set a value: key=value")
-def config_cmd(set_value: str | None) -> None:
-    """Show or update current merged config."""
-    if set_value is not None:
-        _config_set(set_value)
+@main.group("config", invoke_without_command=True)
+@click.option("--set", "set_pair", default=None, help="(compat) Set a value: key=value")
+@click.pass_context
+def config_cmd(ctx: click.Context, set_pair: str | None) -> None:
+    """Show or update configuration.
+
+    Bare `qracer config` lists all settings. Use `config set <key> <value>` to
+    change one, `config get <key>` to read one, and `config providers` to
+    enable/disable providers and set their API keys interactively.
+    """
+    if set_pair is not None:  # backward-compatible `config --set key=value`
+        if "=" not in set_pair:
+            raise click.BadParameter("Expected key=value format", param_hint="--set")
+        key, _, value = set_pair.partition("=")
+        _apply_setting(key.strip(), value.strip())
         return
+    if ctx.invoked_subcommand is None:
+        _show_settings()
+
+
+def _apply_setting(key: str, raw_value: str) -> None:
+    """Validate *raw_value* against the schema and persist it via the config writer."""
+    from qracer.config import settings_schema as ss
+
+    setting = ss.find(key)
+    if setting is None:
+        raise click.ClickException(
+            f"Unknown setting {key!r}. Run 'qracer config' to see available keys."
+        )
+    try:
+        value = ss.coerce(setting, raw_value)
+        ss.validate(setting, value)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if setting.target == "config":
+        writer.set_config_value(setting.key, value)
+    else:
+        writer.set_portfolio_value(setting.key, value)
+    click.echo(f"Set {setting.key} = {value}")
+
+
+@config_cmd.command("set")
+@click.argument("key")
+@click.argument("value")
+def config_set(key: str, value: str) -> None:
+    """Set a setting: qracer config set <key> <value>."""
+    _apply_setting(key, value)
+
+
+@config_cmd.command("get")
+@click.argument("key")
+def config_get(key: str) -> None:
+    """Print the current value of a setting."""
+    from qracer.config import settings_schema as ss
+
+    setting = ss.find(key)
+    if setting is None:
+        raise click.ClickException(f"Unknown setting {key!r}.")
+    click.echo(ss.get_current(load_config(force_reload=True), setting))
+
+
+@config_cmd.command("providers")
+def config_providers() -> None:
+    """Interactively enable/disable providers and set their API keys."""
+    from qracer.config import settings_schema as ss
+
+    while True:
+        rows = ss.provider_settings(load_config(force_reload=True))
+        click.echo("\nProviders:")
+        for r in rows:
+            state = "on " if r.enabled else "off"
+            key = "" if not r.api_key_env else (" key:set" if r.has_key else " key:missing")
+            click.echo(f"  [{state}] {r.name} ({r.kind}, prio {r.priority}){key}")
+        name = click.prompt(
+            "\nProvider to configure (blank to finish)", default="", show_default=False
+        ).strip()
+        if not name:
+            break
+        row = next((r for r in rows if r.name == name), None)
+        if row is None:
+            click.echo(f"  Unknown provider {name!r}.")
+            continue
+        enable = click.confirm(f"  Enable {name}?", default=row.enabled)
+        writer.set_provider_field(name, "enabled", enable)
+        if row.api_key_env:
+            entered = click.prompt(
+                f"  {row.api_key_env} (blank keeps current)", default="", show_default=False
+            ).strip()
+            if entered:
+                writer.set_credential(row.api_key_env, entered)
+        click.echo(f"  Saved {name}.")
+    click.echo("Done.")
+
+
+def _show_settings() -> None:
+    """Print all settings grouped by section, with current values (keys masked)."""
+    from qracer.config import settings_schema as ss
 
     cfg = load_config(force_reload=True)
-    click.echo(cfg.model_dump_json(indent=2))
-
-
-def _config_set(pair: str) -> None:
-    """Write key=value into ~/.qracer/config.toml."""
-    if "=" not in pair:
-        raise click.BadParameter("Expected key=value format", param_hint="--set")
-
-    key, _, value = pair.partition("=")
-    key = key.strip()
-    value = value.strip()
-
-    home_dir = _user_dir()
-    config_path = home_dir / "config.toml"
-
-    if not config_path.exists():
-        click.echo("No config.toml found. Run 'qracer install' first.")
-        raise SystemExit(1)
-
-    # Load existing, update, and write back
-    data = _load_toml(config_path)
-    data[key] = value
-    _write_toml(config_path, data)
-    click.echo(f"Set {key}={value} in {config_path}")
-
-
-def _write_toml(path: Path, data: dict[str, object]) -> None:
-    """Write a flat dict back to TOML."""
-    lines: list[str] = []
-    for k, v in data.items():
-        if isinstance(v, bool):
-            lines.append(f"{k} = {'true' if v else 'false'}")
-        elif isinstance(v, (int, float)):
-            lines.append(f"{k} = {v}")
-        else:
-            lines.append(f'{k} = "{v}"')
-    path.write_text("\n".join(lines) + "\n")
+    for group in ss.groups():
+        click.echo(f"\n{group}:")
+        for s in ss.APP_SETTINGS:
+            if s.group == group:
+                click.echo(f"  {s.key} = {ss.get_current(cfg, s)}")
+    click.echo("\nProviders:")
+    for r in ss.provider_settings(cfg):
+        state = "on " if r.enabled else "off"
+        key = "" if not r.api_key_env else (" key:set" if r.has_key else " key:missing")
+        click.echo(f"  [{state}] {r.name} ({r.kind}, prio {r.priority}){key}")
+    click.echo("\nEdit with:  qracer config set <key> <value>  |  qracer config providers")
 
 
 # ---------------------------------------------------------------------------

--- a/qracer/cli.py
+++ b/qracer/cli.py
@@ -138,18 +138,15 @@ def install() -> None:
     # 1. Create directory
     home_dir.mkdir(parents=True, exist_ok=True)
 
-    # 2. Copy default config files (remembering which we actually created, so the
-    #    wizard's choices below only touch files we own — never an existing setup).
-    created: dict[str, bool] = {}
+    # 2. Copy default config files for any that don't exist yet (existing files are
+    #    left in place; the wizard's choices below are applied as surgical, comment-
+    #    preserving upserts via the writer, so re-running install is safe).
     for name in ("config.toml", "providers.toml", "portfolio.toml"):
-        src = SCHEMA_DIR / name
         dest = home_dir / name
         if dest.exists():
-            created[name] = False
-            click.echo(f"  {name} already exists, skipping.")
+            click.echo(f"  {name} already exists, keeping it.")
         else:
-            shutil.copy2(src, dest)
-            created[name] = True
+            shutil.copy2(SCHEMA_DIR / name, dest)
             click.echo(f"  Created {name}")
 
     # 3. LLM provider selection
@@ -181,22 +178,18 @@ def install() -> None:
         writer.set_credential(chosen_env, creds[chosen_env], config_dir=home_dir)
     (home_dir / "credentials.env").touch(exist_ok=True)  # always present, even if empty
 
-    # 7. Enable the chosen LLM provider (disable the others) — only in a providers.toml
-    #    we just created, so re-running install never disturbs an existing setup.
-    if created["providers.toml"]:
-        for name, _, _ in llm_choices:
-            writer.set_provider_field(name, "enabled", name == chosen_name, config_dir=home_dir)
+    # 7. Enable the chosen LLM provider, disable the others (surgical upsert).
+    for name, _, _ in llm_choices:
+        writer.set_provider_field(name, "enabled", name == chosen_name, config_dir=home_dir)
 
-    # 7b. Persist provider (+ OpenRouter model) choice to a freshly-created config.toml.
-    if created["config.toml"]:
-        writer.set_config_value("llm_provider", chosen_name, config_dir=home_dir)
-        if openrouter_model:
-            writer.set_config_value("llm_model", openrouter_model, config_dir=home_dir)
+    # 7b. Persist provider (+ OpenRouter model) choice to config.toml.
+    writer.set_config_value("llm_provider", chosen_name, config_dir=home_dir)
     if openrouter_model:
+        writer.set_config_value("llm_model", openrouter_model, config_dir=home_dir)
         click.echo(f"  Model set to {openrouter_model}")
 
-    # 8. Update portfolio currency if non-default (only in a portfolio.toml we created).
-    if created["portfolio.toml"] and currency and currency != "USD":
+    # 8. Update portfolio currency if non-default.
+    if currency and currency != "USD":
         writer.set_portfolio_value("currency", currency, config_dir=home_dir)
 
     click.echo(f"\n✓ Setup complete! {chosen_label} enabled as LLM provider.")
@@ -320,6 +313,8 @@ def config_cmd(ctx: click.Context, set_pair: str | None) -> None:
     enable/disable providers and set their API keys interactively.
     """
     if set_pair is not None:  # backward-compatible `config --set key=value`
+        if ctx.invoked_subcommand is not None:
+            raise click.UsageError("--set cannot be combined with a subcommand.")
         if "=" not in set_pair:
             raise click.BadParameter("Expected key=value format", param_hint="--set")
         key, _, value = set_pair.partition("=")

--- a/qracer/config/loader.py
+++ b/qracer/config/loader.py
@@ -7,7 +7,10 @@ Resolution order (first found wins):
 
 Merge strategy:
     - Project-local values override user-default values per file.
-    - credentials.env is always loaded from ~/.qracer/ only.
+    - credentials.env is loaded from QRACER_CONFIG_DIR if set, else ~/.qracer/ —
+      the same location the config writer writes to, so a saved key is read back.
+      It is deliberately NOT read from the project-local ./.qracer/ (avoids picking
+      up a secrets file committed to a repo).
 """
 
 from __future__ import annotations
@@ -130,9 +133,20 @@ def _load_merged_toml(filename: str, dirs: list[Path]) -> dict[str, Any]:
     return result
 
 
+def _credentials_dir() -> Path:
+    """Directory credentials.env is read from: QRACER_CONFIG_DIR if set, else ~/.qracer/.
+
+    Mirrors the config writer's resolution so a key written via ``qracer config`` or
+    the web Settings tab is read back. Project-local ``./.qracer/`` is intentionally
+    excluded so a repo-committed secrets file is never picked up implicitly.
+    """
+    env_dir = os.environ.get("QRACER_CONFIG_DIR")
+    return Path(env_dir) if env_dir else _user_dir()
+
+
 def _load_credentials() -> dict[str, str]:
-    """Load credentials.env from the user-level directory only."""
-    creds_path = _user_dir() / _CREDENTIALS_FILE
+    """Load credentials.env from the resolved credentials directory."""
+    creds_path = _credentials_dir() / _CREDENTIALS_FILE
     if not creds_path.is_file():
         return {}
     values = dotenv_values(creds_path)

--- a/qracer/config/settings_schema.py
+++ b/qracer/config/settings_schema.py
@@ -1,0 +1,274 @@
+"""Declarative settings registry — the single source of truth for editable config.
+
+Each user-facing setting is described once as a :class:`Setting`. Both front-ends
+render from this list: the CLI (`qracer config`) turns them into prompts/validation,
+and the web Settings tab turns them into form widgets. Adding a setting = one entry
+here, and it appears in both places.
+
+Providers straddle two files (``providers.toml`` for enable/priority and
+``credentials.env`` for the API key), so they get their own :class:`ProviderRow`
+derived from the provider catalog + current config via :func:`provider_settings`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qracer.config.models import QracerConfig
+
+_SCHEMA_DIR = Path(__file__).parent / "schema"
+
+
+# ---------------------------------------------------------------------------
+# Scalar settings (config.toml / portfolio.toml)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Setting:
+    """One editable scalar setting.
+
+    ``key`` is the dotted path within its file (which mirrors the attribute path
+    under ``cfg.app`` for ``config`` targets and ``cfg.portfolio`` for ``portfolio``).
+    """
+
+    key: str
+    target: str  # "config" | "portfolio"
+    label: str
+    group: str
+    kind: str  # "bool" | "int" | "float" | "str" | "choice" | "cron"
+    choices: tuple[str, ...] | None = None
+    help: str = ""
+    validator: Callable[[object], str | None] | None = None
+
+
+def _cron_validator(value: object) -> str | None:
+    from qracer.agents_store import validate_cron
+
+    return None if validate_cron(str(value)) else f"Invalid cron expression: {value!r}"
+
+
+APP_SETTINGS: tuple[Setting, ...] = (
+    # -- General --
+    Setting(
+        "default_mode",
+        "config",
+        "Default mode",
+        "General",
+        "choice",
+        choices=("quick", "deep"),
+        help="Analysis depth for a bare query.",
+    ),
+    Setting(
+        "llm_provider",
+        "config",
+        "LLM provider",
+        "General",
+        "str",
+        help="Active LLM provider name (must be enabled in Providers).",
+    ),
+    Setting("llm_model", "config", "LLM model", "General", "str"),
+    Setting(
+        "language",
+        "config",
+        "Language",
+        "General",
+        "str",
+        help="Response language code (e.g. en, ko).",
+    ),
+    # -- Analysis --
+    Setting("max_iterations", "config", "Max iterations", "Analysis", "int"),
+    Setting(
+        "confidence_threshold",
+        "config",
+        "Confidence threshold",
+        "Analysis",
+        "float",
+        help="0.0–1.0; stop early once confidence exceeds this.",
+    ),
+    Setting("lookback_days", "config", "Lookback days", "Analysis", "int"),
+    Setting("staleness_hours", "config", "Staleness hours", "Analysis", "int"),
+    # -- Autonomous monitoring --
+    Setting("autonomous_enabled", "config", "Autonomous monitoring", "Autonomous", "bool"),
+    Setting("price_move_threshold_pct", "config", "Price-move alert %", "Autonomous", "float"),
+    Setting("alert_cooldown_minutes", "config", "Alert cooldown (min)", "Autonomous", "int"),
+    # -- Daily briefing --
+    Setting("briefing.enabled", "config", "Briefing enabled", "Briefing", "bool"),
+    Setting(
+        "briefing.schedule",
+        "config",
+        "Briefing schedule",
+        "Briefing",
+        "cron",
+        help="cron expression (e.g. '0 8 * * 1-5').",
+        validator=_cron_validator,
+    ),
+    Setting(
+        "briefing.timezone",
+        "config",
+        "Briefing timezone",
+        "Briefing",
+        "str",
+        help="IANA tz (e.g. America/New_York); blank = local.",
+    ),
+    Setting("briefing.top_n", "config", "Briefing items", "Briefing", "int"),
+    # -- Portfolio --
+    Setting("currency", "portfolio", "Currency", "Portfolio", "str"),
+    Setting(
+        "limits.max_single_position_pct", "portfolio", "Max single position %", "Portfolio", "float"
+    ),
+    Setting("limits.max_sector_pct", "portfolio", "Max sector %", "Portfolio", "float"),
+    Setting(
+        "limits.max_drawdown_alert_pct", "portfolio", "Max drawdown alert %", "Portfolio", "float"
+    ),
+)
+
+_BY_KEY: dict[str, Setting] = {s.key: s for s in APP_SETTINGS}
+
+
+def find(key: str) -> Setting | None:
+    """Look up a setting by its dotted key (None if unknown)."""
+    return _BY_KEY.get(key)
+
+
+def require(key: str) -> Setting:
+    """Look up a setting by key, raising ``KeyError`` if it does not exist."""
+    setting = _BY_KEY.get(key)
+    if setting is None:
+        raise KeyError(f"Unknown setting {key!r}")
+    return setting
+
+
+def groups() -> list[str]:
+    """Ordered, de-duplicated list of setting groups."""
+    seen: list[str] = []
+    for s in APP_SETTINGS:
+        if s.group not in seen:
+            seen.append(s.group)
+    return seen
+
+
+def get_current(cfg: "QracerConfig", setting: Setting) -> object:
+    """Read a setting's current value from a loaded config.
+
+    The dotted key mirrors the attribute path under ``cfg.app`` (config target)
+    or ``cfg.portfolio`` (portfolio target).
+    """
+    node: object = cfg.app if setting.target == "config" else cfg.portfolio
+    for part in setting.key.split("."):
+        node = getattr(node, part)
+    return node
+
+
+def coerce(setting: Setting, raw: str) -> object:
+    """Coerce a raw string (CLI input) to the setting's type. Raises ValueError."""
+    kind = setting.kind
+    if kind == "bool":
+        low = raw.strip().lower()
+        if low in ("true", "1", "yes", "on"):
+            return True
+        if low in ("false", "0", "no", "off"):
+            return False
+        raise ValueError(f"Expected a boolean (true/false), got {raw!r}")
+    if kind == "int":
+        return int(raw)
+    if kind == "float":
+        return float(raw)
+    # str / choice / cron
+    return raw
+
+
+def validate(setting: Setting, value: object) -> None:
+    """Validate a coerced value against choices + a custom validator. Raises ValueError."""
+    if setting.choices is not None and value not in setting.choices:
+        raise ValueError(f"{setting.key} must be one of {', '.join(setting.choices)}")
+    if setting.validator is not None:
+        err = setting.validator(value)
+        if err:
+            raise ValueError(err)
+
+
+# ---------------------------------------------------------------------------
+# Providers (providers.toml + credentials.env)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProviderRow:
+    """Current state of one provider, for the Providers settings group."""
+
+    name: str
+    kind: str  # "data" | "llm"
+    enabled: bool
+    priority: int
+    api_key_env: str | None
+    has_key: bool
+
+
+def _schema_providers() -> dict[str, dict]:
+    from qracer.config.loader import _load_toml
+
+    return _load_toml(_SCHEMA_DIR / "providers.toml").get("providers", {})
+
+
+def provider_settings(
+    cfg: "QracerConfig", credentials: dict[str, str] | None = None
+) -> list[ProviderRow]:
+    """Build provider rows from the catalog (schema + entry points) overlaid with config.
+
+    Enabled/priority/api_key_env come from the user's config when present, else the
+    packaged schema defaults. ``has_key`` reflects credentials.env or the process env.
+    """
+    from qracer.provider_catalog import discover_data_providers, discover_llm_providers
+
+    creds = credentials if credentials is not None else dict(cfg.credentials)
+    schema = _schema_providers()
+
+    # Known provider name -> kind, from the runtime catalog (built-ins + plugins).
+    kinds: dict[str, str] = {}
+    for name in discover_data_providers():
+        kinds[name] = "data"
+    for name in discover_llm_providers():
+        kinds[name] = "llm"
+    # Include any schema-declared providers even if the adapter import is unavailable.
+    for name, meta in schema.items():
+        kinds.setdefault(name, meta.get("kind", "data"))
+
+    rows: list[ProviderRow] = []
+    for name in sorted(kinds):
+        current = cfg.providers.providers.get(name)
+        sch = schema.get(name, {})
+        api_key_env = (current.api_key_env if current else None) or sch.get("api_key_env")
+        enabled = current.enabled if current else bool(sch.get("enabled", False))
+        priority = current.priority if current else int(sch.get("priority", 100))
+        has_key = bool(api_key_env and (creds.get(api_key_env) or os.environ.get(api_key_env)))
+        rows.append(
+            ProviderRow(
+                name=name,
+                kind=kinds[name],
+                enabled=enabled,
+                priority=priority,
+                api_key_env=api_key_env,
+                has_key=has_key,
+            )
+        )
+    return rows
+
+
+__all__ = [
+    "APP_SETTINGS",
+    "ProviderRow",
+    "Setting",
+    "coerce",
+    "find",
+    "get_current",
+    "groups",
+    "provider_settings",
+    "require",
+    "validate",
+]

--- a/qracer/config/writer.py
+++ b/qracer/config/writer.py
@@ -14,12 +14,14 @@ so the helpful default comments are preserved.
 
 from __future__ import annotations
 
+import copy
 import os
 import shutil
 from pathlib import Path
 from typing import Any
 
 import tomlkit
+from dotenv import dotenv_values
 from tomlkit.items import Table
 
 from qracer.config.loader import _user_dir
@@ -75,7 +77,9 @@ def _set_dotted(doc: tomlkit.TOMLDocument, dotted_key: str, value: object) -> No
     node: Any = doc
     for part in parts[:-1]:
         child = node.get(part)
-        if child is None:
+        # Create (or replace a stray scalar with) an intermediate table so a
+        # malformed file like `briefing = "x"` can't crash the write.
+        if not isinstance(child, Table):
             child = tomlkit.table()
             node[part] = child
         node = child
@@ -114,13 +118,12 @@ def _schema_provider_block(name: str) -> Table:
     """A fresh table seeded from the schema's ``[providers.<name>]`` (defaults if unknown)."""
     schema = _load_doc(_SCHEMA_DIR / "providers.toml")
     src = schema.get("providers", {}).get(name)
-    table = tomlkit.table()
     if src is not None:
-        for key, val in dict(src).items():
-            table[key] = val
-    else:  # unknown provider — minimal sane defaults
-        table["enabled"] = False
-        table["priority"] = 50
+        # Deep-copy the schema item so its comments/formatting come along.
+        return copy.deepcopy(src)
+    table = tomlkit.table()  # unknown provider — minimal sane defaults
+    table["enabled"] = False
+    table["priority"] = 50
     return table
 
 
@@ -197,18 +200,15 @@ def unset_credential(env_key: str, config_dir: Path | None = None) -> Path:
 
 
 def read_credentials(config_dir: Path | None = None) -> dict[str, str]:
-    """Return the ``credentials.env`` key/value pairs (empty if the file is absent)."""
+    """Return the ``credentials.env`` key/value pairs (empty if the file is absent).
+
+    Uses the same ``dotenv`` parser as the loader so the values match exactly
+    (quote stripping, ``export`` prefixes, inline comments).
+    """
     path = _credentials_path(config_dir)
     if not path.exists():
         return {}
-    result: dict[str, str] = {}
-    for line in path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or "=" not in stripped:
-            continue
-        key, _, val = stripped.partition("=")
-        result[key.strip()] = val.strip()
-    return result
+    return {k: v for k, v in dotenv_values(path).items() if v is not None}
 
 
 __all__ = [

--- a/qracer/config/writer.py
+++ b/qracer/config/writer.py
@@ -1,0 +1,221 @@
+"""Structured, comment-preserving writer for the .qracer/ config files.
+
+This is the single write path for configuration, used by both the CLI
+(`qracer config`, `qracer install`) and the web Settings tab. Unlike the old
+regex / flat-dict hacks it uses ``tomlkit`` for round-trip editing, so existing
+comments, formatting, and nested tables (``[briefing]``, ``[providers.*]``,
+``[limits]``) survive an edit.
+
+Writes go to ``~/.qracer/`` by default (the canonical writable location); a
+``config_dir`` override is accepted for tests and for the web layer. When a
+target file does not exist yet it is seeded from the packaged schema template
+so the helpful default comments are preserved.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import tomlkit
+from tomlkit.items import Table
+
+from qracer.config.loader import _user_dir
+
+_SCHEMA_DIR = Path(__file__).parent / "schema"
+_CREDENTIALS_FILE = "credentials.env"
+
+
+# ---------------------------------------------------------------------------
+# Low-level file helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_dir(config_dir: Path | None) -> Path:
+    """Directory to write into.
+
+    An explicit ``config_dir`` wins; otherwise honor ``$QRACER_CONFIG_DIR`` so
+    reads and writes target the same directory, falling back to ``~/.qracer/``.
+    """
+    if config_dir is not None:
+        return config_dir
+    env_dir = os.environ.get("QRACER_CONFIG_DIR")
+    return Path(env_dir) if env_dir else _user_dir()
+
+
+def _ensure_toml(config_dir: Path | None, filename: str) -> Path:
+    """Return the path to *filename*, seeding it from the schema template if absent."""
+    base = _resolve_dir(config_dir)
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / filename
+    if not path.exists():
+        template = _SCHEMA_DIR / filename
+        if template.exists():
+            shutil.copy2(template, path)
+        else:  # pragma: no cover - all config files have a template
+            path.write_text("", encoding="utf-8")
+    return path
+
+
+def _load_doc(path: Path) -> tomlkit.TOMLDocument:
+    if path.exists():
+        return tomlkit.parse(path.read_text(encoding="utf-8"))
+    return tomlkit.document()
+
+
+def _write_doc(path: Path, doc: tomlkit.TOMLDocument) -> None:
+    path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+
+def _set_dotted(doc: tomlkit.TOMLDocument, dotted_key: str, value: object) -> None:
+    """Set ``a.b.c = value``, creating intermediate tables as needed."""
+    parts = dotted_key.split(".")
+    node: Any = doc
+    for part in parts[:-1]:
+        child = node.get(part)
+        if child is None:
+            child = tomlkit.table()
+            node[part] = child
+        node = child
+    node[parts[-1]] = value
+
+
+# ---------------------------------------------------------------------------
+# config.toml / portfolio.toml
+# ---------------------------------------------------------------------------
+
+
+def set_config_value(dotted_key: str, value: object, config_dir: Path | None = None) -> Path:
+    """Set a value in ``config.toml`` (e.g. ``default_mode`` or ``briefing.schedule``)."""
+    path = _ensure_toml(config_dir, "config.toml")
+    doc = _load_doc(path)
+    _set_dotted(doc, dotted_key, value)
+    _write_doc(path, doc)
+    return path
+
+
+def set_portfolio_value(dotted_key: str, value: object, config_dir: Path | None = None) -> Path:
+    """Set a value in ``portfolio.toml`` (e.g. ``currency`` or ``limits.max_sector_pct``)."""
+    path = _ensure_toml(config_dir, "portfolio.toml")
+    doc = _load_doc(path)
+    _set_dotted(doc, dotted_key, value)
+    _write_doc(path, doc)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# providers.toml
+# ---------------------------------------------------------------------------
+
+
+def _schema_provider_block(name: str) -> Table:
+    """A fresh table seeded from the schema's ``[providers.<name>]`` (defaults if unknown)."""
+    schema = _load_doc(_SCHEMA_DIR / "providers.toml")
+    src = schema.get("providers", {}).get(name)
+    table = tomlkit.table()
+    if src is not None:
+        for key, val in dict(src).items():
+            table[key] = val
+    else:  # unknown provider — minimal sane defaults
+        table["enabled"] = False
+        table["priority"] = 50
+    return table
+
+
+def set_provider_field(
+    name: str, field: str, value: object, config_dir: Path | None = None
+) -> Path:
+    """Set ``[providers.<name>] <field> = value`` in ``providers.toml``.
+
+    Creates the provider block (seeded from the schema) if the user's file does
+    not have it yet.
+    """
+    path = _ensure_toml(config_dir, "providers.toml")
+    doc = _load_doc(path)
+    providers = doc.get("providers")
+    if providers is None:
+        providers = tomlkit.table(is_super_table=True)
+        doc["providers"] = providers
+    if name not in providers:
+        providers[name] = _schema_provider_block(name)
+    providers[name][field] = value
+    _write_doc(path, doc)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# credentials.env (dotenv, not TOML)
+# ---------------------------------------------------------------------------
+
+
+def _credentials_path(config_dir: Path | None) -> Path:
+    base = _resolve_dir(config_dir)
+    base.mkdir(parents=True, exist_ok=True)
+    return base / _CREDENTIALS_FILE
+
+
+def set_credential(env_key: str, value: str, config_dir: Path | None = None) -> Path:
+    """Upsert ``env_key=value`` in ``credentials.env``, preserving other lines/comments."""
+    path = _credentials_path(config_dir)
+    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    new_line = f"{env_key}={value}"
+    replaced = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if (
+            stripped
+            and not stripped.startswith("#")
+            and stripped.split("=", 1)[0].strip() == env_key
+        ):
+            lines[i] = new_line
+            replaced = True
+            break
+    if not replaced:
+        lines.append(new_line)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def unset_credential(env_key: str, config_dir: Path | None = None) -> Path:
+    """Remove ``env_key`` from ``credentials.env`` (no-op if absent)."""
+    path = _credentials_path(config_dir)
+    if not path.exists():
+        return path
+    kept = [
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if not (
+            line.strip()
+            and not line.strip().startswith("#")
+            and line.strip().split("=", 1)[0].strip() == env_key
+        )
+    ]
+    path.write_text(("\n".join(kept) + "\n") if kept else "", encoding="utf-8")
+    return path
+
+
+def read_credentials(config_dir: Path | None = None) -> dict[str, str]:
+    """Return the ``credentials.env`` key/value pairs (empty if the file is absent)."""
+    path = _credentials_path(config_dir)
+    if not path.exists():
+        return {}
+    result: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, val = stripped.partition("=")
+        result[key.strip()] = val.strip()
+    return result
+
+
+__all__ = [
+    "read_credentials",
+    "set_config_value",
+    "set_credential",
+    "set_portfolio_value",
+    "set_provider_field",
+    "unset_credential",
+]

--- a/qracer/web/dashboard.py
+++ b/qracer/web/dashboard.py
@@ -144,6 +144,7 @@ def mount(
     from qracer.alerts import AlertStore
     from qracer.tasks import TaskStore
     from qracer.watchlist import Watchlist
+    from qracer.web.settings_ui import render_settings_section
     from qracer.web.ui import render_agents_section
 
     watchlist = Watchlist(base_dir / "watchlist.json")
@@ -360,6 +361,7 @@ def mount(
             t_tasks = ui.tab("Tasks")
             t_agents = ui.tab("Agents")
             t_theses = ui.tab("Theses")
+            t_settings = ui.tab("Settings")
 
         with ui.tab_panels(tabs, value=t_overview).classes("w-full"):
             with ui.tab_panel(t_overview):
@@ -376,6 +378,8 @@ def mount(
                 render_agents_section(base_dir)
             with ui.tab_panel(t_theses):
                 theses_section()
+            with ui.tab_panel(t_settings):
+                render_settings_section(base_dir)
 
         # Populate off the render path so the page shows immediately, and let NiceGUI
         # own the tasks (a bare asyncio.create_task result can be garbage-collected).

--- a/qracer/web/settings_ui.py
+++ b/qracer/web/settings_ui.py
@@ -24,15 +24,31 @@ from qracer.config.loader import load_config
 
 
 def _coerce_widget(setting: ss.Setting, value: object) -> object:
-    """Coerce a widget value to the setting's type. Raises ValueError."""
+    """Coerce a widget value to the setting's type. Raises ValueError.
+
+    A blank numeric field arrives as ``None``; surface that as a clean ValueError
+    rather than letting ``int(None)`` raise TypeError past the caller's handler.
+    """
     kind = setting.kind
-    if kind == "int":
-        return int(value)  # type: ignore[arg-type]
-    if kind == "float":
-        return float(value)  # type: ignore[arg-type]
+    if kind in ("int", "float"):
+        if value is None or value == "":
+            raise ValueError(f"{setting.label} must be a number")
+        try:
+            return int(value) if kind == "int" else float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{setting.label} must be a number") from exc
     if kind == "bool":
         return bool(value)
     return "" if value is None else str(value)
+
+
+def _coerce_priority(value: object) -> int:
+    if value is None or value == "":
+        raise ValueError("Priority must be a number")
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Priority must be a number") from exc
 
 
 def apply_scalar(setting: ss.Setting, value: object, config_dir: Path | None = None) -> object:
@@ -46,6 +62,24 @@ def apply_scalar(setting: ss.Setting, value: object, config_dir: Path | None = N
     return coerced
 
 
+def apply_group(items: list[tuple[ss.Setting, object]], config_dir: Path | None = None) -> None:
+    """Validate ALL settings in a group, then persist them — atomic on failure.
+
+    If any value fails coercion/validation, ValueError is raised before any write,
+    so a mid-group error never leaves a partial save on disk.
+    """
+    coerced: list[tuple[ss.Setting, object]] = []
+    for setting, value in items:
+        c = _coerce_widget(setting, value)
+        ss.validate(setting, c)
+        coerced.append((setting, c))
+    for setting, c in coerced:
+        if setting.target == "config":
+            writer.set_config_value(setting.key, c, config_dir=config_dir)
+        else:
+            writer.set_portfolio_value(setting.key, c, config_dir=config_dir)
+
+
 def apply_provider(
     name: str,
     enabled: bool,
@@ -54,9 +88,10 @@ def apply_provider(
     key_value: str,
     config_dir: Path | None = None,
 ) -> None:
-    """Persist a provider's enabled/priority and (if provided) its API key."""
+    """Persist a provider's enabled/priority and (if provided) its API key. Raises ValueError."""
+    prio = _coerce_priority(priority)  # validate before any write
     writer.set_provider_field(name, "enabled", bool(enabled), config_dir=config_dir)
-    writer.set_provider_field(name, "priority", int(priority), config_dir=config_dir)  # type: ignore[arg-type]
+    writer.set_provider_field(name, "priority", prio, config_dir=config_dir)
     if api_key_env and key_value:
         writer.set_credential(api_key_env, key_value, config_dir=config_dir)
 
@@ -85,18 +120,17 @@ def render_settings_section(base_dir: Path) -> None:
                     widgets[setting.key] = _scalar_widget(ui, setting, ss.get_current(cfg, setting))
 
                 def save_group(bound_widgets: dict = widgets) -> None:
-                    saved = 0
-                    for key, widget in bound_widgets.items():
-                        setting = ss.find(key)
-                        if setting is None:
-                            continue
-                        try:
-                            apply_scalar(setting, widget.value, config_dir=base_dir)  # type: ignore[attr-defined]
-                            saved += 1
-                        except ValueError as exc:
-                            ui.notify(f"{key}: {exc}", type="negative")
-                            return
-                    ui.notify(f"Saved {saved} setting(s)", type="positive")
+                    items = [
+                        (setting, widget.value)  # type: ignore[attr-defined]
+                        for key, widget in bound_widgets.items()
+                        if (setting := ss.find(key)) is not None
+                    ]
+                    try:
+                        apply_group(items, config_dir=base_dir)  # validates all before writing
+                    except ValueError as exc:
+                        ui.notify(str(exc), type="negative")
+                        return
+                    ui.notify(f"Saved {len(items)} setting(s)", type="positive")
                     settings_form.refresh()
 
                 ui.button("Save", on_click=save_group).props("color=primary")
@@ -122,7 +156,9 @@ def _scalar_widget(ui: object, setting: ss.Setting, current: object) -> object:
         return ui.select(list(setting.choices or ()), value=current, label=label).classes(  # type: ignore[attr-defined]
             "w-64"
         )
-    if setting.kind in ("int", "float"):
+    if setting.kind == "int":
+        return ui.number(label, value=current, format="%.0f", step=1).classes("w-64")  # type: ignore[attr-defined]
+    if setting.kind == "float":
         return ui.number(label, value=current).classes("w-64")  # type: ignore[attr-defined]
     # str / cron
     text = "" if current is None else str(current)
@@ -165,4 +201,4 @@ def _provider_card(ui: object, row: ss.ProviderRow, base_dir: Path, on_saved: ob
         ui.button("Save", on_click=save).props("color=primary flat")  # type: ignore[attr-defined]
 
 
-__all__ = ["apply_provider", "apply_scalar", "render_settings_section"]
+__all__ = ["apply_group", "apply_provider", "apply_scalar", "render_settings_section"]

--- a/qracer/web/settings_ui.py
+++ b/qracer/web/settings_ui.py
@@ -1,0 +1,168 @@
+"""NiceGUI Settings section — the editable config surface for the web dashboard.
+
+Renders the declarative settings registry (:mod:`qracer.config.settings_schema`) as
+grouped forms plus a Providers group, and writes changes through the structured
+config writer (:mod:`qracer.config.writer`). This is the web twin of ``qracer config``:
+both front-ends share the same schema and the same write path.
+
+Mirrors the in-process pattern of :func:`qracer.web.ui.render_agents_section` — no REST
+round-trip. API keys are entered masked (``password``) and are write-only: an existing
+key is shown as "set", never echoed back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from qracer.config import settings_schema as ss
+from qracer.config import writer
+from qracer.config.loader import load_config
+
+# ---------------------------------------------------------------------------
+# Pure apply helpers (no NiceGUI) — unit-tested directly
+# ---------------------------------------------------------------------------
+
+
+def _coerce_widget(setting: ss.Setting, value: object) -> object:
+    """Coerce a widget value to the setting's type. Raises ValueError."""
+    kind = setting.kind
+    if kind == "int":
+        return int(value)  # type: ignore[arg-type]
+    if kind == "float":
+        return float(value)  # type: ignore[arg-type]
+    if kind == "bool":
+        return bool(value)
+    return "" if value is None else str(value)
+
+
+def apply_scalar(setting: ss.Setting, value: object, config_dir: Path | None = None) -> object:
+    """Validate + persist one scalar setting; returns the stored value. Raises ValueError."""
+    coerced = _coerce_widget(setting, value)
+    ss.validate(setting, coerced)
+    if setting.target == "config":
+        writer.set_config_value(setting.key, coerced, config_dir=config_dir)
+    else:
+        writer.set_portfolio_value(setting.key, coerced, config_dir=config_dir)
+    return coerced
+
+
+def apply_provider(
+    name: str,
+    enabled: bool,
+    priority: object,
+    api_key_env: str | None,
+    key_value: str,
+    config_dir: Path | None = None,
+) -> None:
+    """Persist a provider's enabled/priority and (if provided) its API key."""
+    writer.set_provider_field(name, "enabled", bool(enabled), config_dir=config_dir)
+    writer.set_provider_field(name, "priority", int(priority), config_dir=config_dir)  # type: ignore[arg-type]
+    if api_key_env and key_value:
+        writer.set_credential(api_key_env, key_value, config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# NiceGUI rendering
+# ---------------------------------------------------------------------------
+
+
+def render_settings_section(base_dir: Path) -> None:
+    """Render the editable Settings section into the current NiceGUI context."""
+    from nicegui import ui
+
+    @ui.refreshable
+    def settings_form() -> None:
+        cfg = load_config(force_reload=True)
+
+        # -- scalar setting groups --
+        for group in ss.groups():
+            with ui.card().classes("w-full"):
+                ui.label(group).classes("font-bold")
+                widgets: dict[str, object] = {}
+                for setting in ss.APP_SETTINGS:
+                    if setting.group != group:
+                        continue
+                    widgets[setting.key] = _scalar_widget(ui, setting, ss.get_current(cfg, setting))
+
+                def save_group(bound_widgets: dict = widgets) -> None:
+                    saved = 0
+                    for key, widget in bound_widgets.items():
+                        setting = ss.find(key)
+                        if setting is None:
+                            continue
+                        try:
+                            apply_scalar(setting, widget.value, config_dir=base_dir)  # type: ignore[attr-defined]
+                            saved += 1
+                        except ValueError as exc:
+                            ui.notify(f"{key}: {exc}", type="negative")
+                            return
+                    ui.notify(f"Saved {saved} setting(s)", type="positive")
+                    settings_form.refresh()
+
+                ui.button("Save", on_click=save_group).props("color=primary")
+
+        # -- providers --
+        with ui.card().classes("w-full"):
+            ui.label("Providers").classes("font-bold")
+            ui.label("Enable a provider and set its API key (write-only).").classes(
+                "text-gray-500 text-sm"
+            )
+            for row in ss.provider_settings(cfg):
+                _provider_card(ui, row, base_dir, settings_form.refresh)
+
+    settings_form()
+
+
+def _scalar_widget(ui: object, setting: ss.Setting, current: object) -> object:
+    """Build the input widget for a scalar setting, seeded with its current value."""
+    label = setting.label
+    if setting.kind == "bool":
+        return ui.switch(label, value=bool(current))  # type: ignore[attr-defined]
+    if setting.kind == "choice":
+        return ui.select(list(setting.choices or ()), value=current, label=label).classes(  # type: ignore[attr-defined]
+            "w-64"
+        )
+    if setting.kind in ("int", "float"):
+        return ui.number(label, value=current).classes("w-64")  # type: ignore[attr-defined]
+    # str / cron
+    text = "" if current is None else str(current)
+    widget = ui.input(label, value=text).classes("w-full")  # type: ignore[attr-defined]
+    if setting.help:
+        widget.tooltip(setting.help)
+    return widget
+
+
+def _provider_card(ui: object, row: ss.ProviderRow, base_dir: Path, on_saved: object) -> None:
+    """Render one provider row: enabled switch, priority, masked key input, Save."""
+    with ui.card().classes("w-full"):  # type: ignore[attr-defined]
+        with ui.row().classes("items-center gap-4 w-full"):  # type: ignore[attr-defined]
+            ui.label(f"{row.name} ({row.kind})").classes("font-bold")  # type: ignore[attr-defined]
+            enabled = ui.switch("Enabled", value=row.enabled)  # type: ignore[attr-defined]
+            priority = ui.number("Priority", value=row.priority).classes("w-32")  # type: ignore[attr-defined]
+        key_input = None
+        if row.api_key_env:
+            placeholder = "•••• set — leave blank to keep" if row.has_key else "not set"
+            key_input = ui.input(  # type: ignore[attr-defined]
+                row.api_key_env, password=True, placeholder=placeholder
+            ).classes("w-full")
+
+        def save(
+            name: str = row.name,
+            env: str | None = row.api_key_env,
+            en: object = enabled,
+            prio: object = priority,
+            key_widget: object = key_input,
+        ) -> None:
+            key_value = (key_widget.value or "").strip() if key_widget is not None else ""  # type: ignore[attr-defined]
+            try:
+                apply_provider(name, en.value, prio.value, env, key_value, config_dir=base_dir)  # type: ignore[attr-defined]
+            except ValueError as exc:
+                ui.notify(str(exc), type="negative")  # type: ignore[attr-defined]
+                return
+            ui.notify(f"Saved {name}", type="positive")  # type: ignore[attr-defined]
+            on_saved()  # type: ignore[operator]
+
+        ui.button("Save", on_click=save).props("color=primary flat")  # type: ignore[attr-defined]
+
+
+__all__ = ["apply_provider", "apply_scalar", "render_settings_section"]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -44,19 +44,26 @@ class TestInstall:
         assert (home_dir / "credentials.env").exists()
         assert "Setup complete" in result.output
 
-    def test_install_skips_existing_files(self, tmp_path: Path) -> None:
+    def test_install_keeps_existing_files_but_applies_choice(self, tmp_path: Path) -> None:
+        # A pre-existing, valid config with a custom marker. Re-running install must
+        # keep the file (and the marker/comment) but surgically apply the new choice.
         home_dir = tmp_path / ".qracer"
         home_dir.mkdir()
-        (home_dir / "config.toml").write_text("existing")
+        (home_dir / "config.toml").write_text(
+            '# my custom note\ndefault_mode = "deep"\nllm_provider = "openai"\n',
+            encoding="utf-8",
+        )
 
         runner = CliRunner()
         with patch("qracer.cli._user_dir", return_value=home_dir):
-            result = runner.invoke(main, ["install"], input="1\n\nUSD\n")
+            result = runner.invoke(main, ["install"], input="1\n\nUSD\n")  # choice 1 = claude
 
         assert result.exit_code == 0
         assert "already exists" in result.output
-        # Existing file should not be overwritten
-        assert (home_dir / "config.toml").read_text() == "existing"
+        content = (home_dir / "config.toml").read_text(encoding="utf-8")
+        assert "# my custom note" in content  # comment preserved
+        assert 'default_mode = "deep"' in content  # untouched key preserved
+        assert 'llm_provider = "claude"' in content  # wizard choice applied via surgical upsert
 
     def test_install_writes_credentials(self, tmp_path: Path) -> None:
         home_dir = tmp_path / ".qracer"
@@ -250,3 +257,15 @@ class TestConfig:
         assert "enabled = true" in providers.split("[providers.dart]", 1)[1]
         creds = (d / "credentials.env").read_text(encoding="utf-8")
         assert "DART_API_KEY=MY_DART_KEY" in creds
+
+    def test_provider_key_round_trips_through_load_config(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        # Regression: a key set via the CLI under QRACER_CONFIG_DIR must actually be
+        # read back by load_config() (writer and loader must resolve the same dir).
+        self._env(monkeypatch, tmp_path)
+        CliRunner().invoke(main, ["config", "providers"], input="dart\ny\nROUNDTRIP\n\n")
+        from qracer.config.loader import load_config
+
+        cfg = load_config(force_reload=True)
+        assert cfg.credentials.get("DART_API_KEY") == "ROUNDTRIP"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -185,48 +185,68 @@ class TestStatus:
 
 
 class TestConfig:
-    def test_config_show(self) -> None:
-        runner = CliRunner()
-        with patch("qracer.cli.load_config") as mock_load:
-            from qracer.config.models import QracerConfig
+    """The `config` command is isolated via QRACER_CONFIG_DIR, which both the
+    loader (reads) and the writer (writes) honor."""
 
-            mock_load.return_value = QracerConfig()
-            result = runner.invoke(main, ["config"])
+    def _env(self, monkeypatch, tmp_path: Path) -> Path:
+        d = tmp_path / ".qracer"
+        d.mkdir()
+        monkeypatch.setenv("QRACER_CONFIG_DIR", str(d))
+        return d
 
+    def test_config_show_lists_groups_and_providers(self, monkeypatch, tmp_path: Path) -> None:
+        self._env(monkeypatch, tmp_path)
+        result = CliRunner().invoke(main, ["config"])
         assert result.exit_code == 0
-        assert '"app"' in result.output
+        assert "General:" in result.output
+        assert "default_mode" in result.output
+        assert "Providers:" in result.output
 
-    def test_config_set(self, tmp_path: Path) -> None:
-        home_dir = tmp_path / ".qracer"
-        home_dir.mkdir()
-        (home_dir / "config.toml").write_text('default_mode = "quick"\n')
+    def test_config_set_nested_and_seeds_file(self, monkeypatch, tmp_path: Path) -> None:
+        d = self._env(monkeypatch, tmp_path)  # no config.toml yet
+        result = CliRunner().invoke(main, ["config", "set", "briefing.schedule", "0 9 * * *"])
+        assert result.exit_code == 0, result.output
+        assert "Set briefing.schedule = 0 9 * * *" in result.output
+        text = (d / "config.toml").read_text(encoding="utf-8")
+        assert "[briefing]" in text and 'schedule = "0 9 * * *"' in text
 
-        runner = CliRunner()
-        with patch("qracer.cli._user_dir", return_value=home_dir):
-            result = runner.invoke(main, ["config", "--set", "default_mode=deep"])
-
+    def test_config_set_compat_flag(self, monkeypatch, tmp_path: Path) -> None:
+        d = self._env(monkeypatch, tmp_path)
+        result = CliRunner().invoke(main, ["config", "--set", "default_mode=deep"])
         assert result.exit_code == 0
-        assert "Set default_mode=deep" in result.output
-        content = (home_dir / "config.toml").read_text()
-        assert "deep" in content
+        assert 'default_mode = "deep"' in (d / "config.toml").read_text(encoding="utf-8")
 
-    def test_config_set_bad_format(self, tmp_path: Path) -> None:
-        runner = CliRunner()
-        home_dir = tmp_path / ".qracer"
-        home_dir.mkdir()
-        (home_dir / "config.toml").write_text("")
+    def test_config_get(self, monkeypatch, tmp_path: Path) -> None:
+        self._env(monkeypatch, tmp_path)
+        CliRunner().invoke(main, ["config", "set", "max_iterations", "9"])
+        result = CliRunner().invoke(main, ["config", "get", "max_iterations"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "9"
 
-        with patch("qracer.cli._user_dir", return_value=home_dir):
-            result = runner.invoke(main, ["config", "--set", "noequals"])
+    def test_config_set_invalid_choice(self, monkeypatch, tmp_path: Path) -> None:
+        self._env(monkeypatch, tmp_path)
+        result = CliRunner().invoke(main, ["config", "set", "default_mode", "sideways"])
+        assert result.exit_code != 0
+        assert "must be one of" in result.output
 
+    def test_config_set_unknown_key(self, monkeypatch, tmp_path: Path) -> None:
+        self._env(monkeypatch, tmp_path)
+        result = CliRunner().invoke(main, ["config", "set", "bogus", "1"])
+        assert result.exit_code != 0
+        assert "Unknown setting" in result.output
+
+    def test_config_set_bad_compat_format(self, monkeypatch, tmp_path: Path) -> None:
+        self._env(monkeypatch, tmp_path)
+        result = CliRunner().invoke(main, ["config", "--set", "noequals"])
         assert result.exit_code != 0
 
-    def test_config_set_no_config_file(self, tmp_path: Path) -> None:
-        home_dir = tmp_path / ".qracer"
-        home_dir.mkdir()  # No config.toml
-
-        runner = CliRunner()
-        with patch("qracer.cli._user_dir", return_value=home_dir):
-            result = runner.invoke(main, ["config", "--set", "key=val"])
-
-        assert result.exit_code != 0
+    def test_config_providers_enables_and_sets_key(self, monkeypatch, tmp_path: Path) -> None:
+        d = self._env(monkeypatch, tmp_path)
+        # Configure 'dart': enable = yes, enter a key, then blank to finish.
+        result = CliRunner().invoke(main, ["config", "providers"], input="dart\ny\nMY_DART_KEY\n\n")
+        assert result.exit_code == 0, result.output
+        providers = (d / "providers.toml").read_text(encoding="utf-8")
+        assert "[providers.dart]" in providers
+        assert "enabled = true" in providers.split("[providers.dart]", 1)[1]
+        creds = (d / "credentials.env").read_text(encoding="utf-8")
+        assert "DART_API_KEY=MY_DART_KEY" in creds

--- a/tests/config/test_settings_schema.py
+++ b/tests/config/test_settings_schema.py
@@ -79,7 +79,10 @@ class TestProviderSettings:
             )
         )
 
-    def test_overlays_config_over_schema(self) -> None:
+    def test_overlays_config_over_schema(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # has_key falls back to os.environ, so neutralize any real key in the env
+        # to keep the assertion hermetic.
+        monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
         rows = ss.provider_settings(self._cfg(), credentials={"DART_API_KEY": "x"})
         by_name = {r.name: r for r in rows}
         # dart reflects the user's config + credential presence.

--- a/tests/config/test_settings_schema.py
+++ b/tests/config/test_settings_schema.py
@@ -1,0 +1,99 @@
+"""Tests for the declarative settings registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from qracer.config import settings_schema as ss
+from qracer.config.models import (
+    AppConfig,
+    BriefingConfig,
+    PortfolioConfig,
+    ProviderConfig,
+    ProvidersConfig,
+    QracerConfig,
+)
+
+
+class TestRegistry:
+    def test_find_and_groups(self) -> None:
+        assert ss.find("default_mode") is not None
+        assert ss.find("nonexistent") is None
+        # Groups are ordered and de-duplicated.
+        assert ss.groups() == ["General", "Analysis", "Autonomous", "Briefing", "Portfolio"]
+
+    def test_every_setting_has_a_valid_target(self) -> None:
+        assert all(s.target in ("config", "portfolio") for s in ss.APP_SETTINGS)
+
+
+class TestGetCurrent:
+    def test_reads_across_app_briefing_and_portfolio(self) -> None:
+        cfg = QracerConfig(
+            app=AppConfig(default_mode="deep", briefing=BriefingConfig(top_n=9)),
+            portfolio=PortfolioConfig(currency="KRW"),
+        )
+        assert ss.get_current(cfg, ss.require("default_mode")) == "deep"
+        assert ss.get_current(cfg, ss.require("briefing.top_n")) == 9
+        assert ss.get_current(cfg, ss.require("currency")) == "KRW"
+        assert ss.get_current(cfg, ss.require("limits.max_sector_pct")) == 40.0  # default
+
+
+class TestCoerce:
+    @pytest.mark.parametrize("raw,expected", [("true", True), ("off", False), ("1", True)])
+    def test_bool(self, raw: str, expected: bool) -> None:
+        assert ss.coerce(ss.require("autonomous_enabled"), raw) is expected
+
+    def test_bool_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="boolean"):
+            ss.coerce(ss.require("autonomous_enabled"), "maybe")
+
+    def test_int_and_float(self) -> None:
+        assert ss.coerce(ss.require("max_iterations"), "5") == 5
+        assert ss.coerce(ss.require("confidence_threshold"), "0.9") == 0.9
+
+    def test_str_passthrough(self) -> None:
+        assert ss.coerce(ss.require("language"), "ko") == "ko"
+
+
+class TestValidate:
+    def test_choice_ok_and_rejected(self) -> None:
+        ss.validate(ss.require("default_mode"), "quick")  # no raise
+        with pytest.raises(ValueError, match="must be one of"):
+            ss.validate(ss.require("default_mode"), "sideways")
+
+    def test_cron_validator(self) -> None:
+        ss.validate(ss.require("briefing.schedule"), "0 8 * * 1-5")  # no raise
+        with pytest.raises(ValueError, match="Invalid cron"):
+            ss.validate(ss.require("briefing.schedule"), "not a cron")
+
+
+class TestProviderSettings:
+    def _cfg(self) -> QracerConfig:
+        return QracerConfig(
+            providers=ProvidersConfig(
+                providers={
+                    "dart": ProviderConfig(
+                        enabled=True, priority=40, api_key_env="DART_API_KEY", kind="data"
+                    ),
+                }
+            )
+        )
+
+    def test_overlays_config_over_schema(self) -> None:
+        rows = ss.provider_settings(self._cfg(), credentials={"DART_API_KEY": "x"})
+        by_name = {r.name: r for r in rows}
+        # dart reflects the user's config + credential presence.
+        assert by_name["dart"].enabled is True
+        assert by_name["dart"].priority == 40
+        assert by_name["dart"].has_key is True
+        # A provider only in the schema (not in cfg) still appears, from schema defaults.
+        assert "finnhub" in by_name
+        assert by_name["finnhub"].enabled is False
+        assert by_name["finnhub"].api_key_env == "FINNHUB_API_KEY"
+        assert by_name["finnhub"].has_key is False
+
+    def test_kinds_are_populated(self) -> None:
+        rows = ss.provider_settings(self._cfg(), credentials={})
+        by_name = {r.name: r for r in rows}
+        assert by_name["dart"].kind == "data"
+        assert by_name["claude"].kind == "llm"

--- a/tests/config/test_writer.py
+++ b/tests/config/test_writer.py
@@ -1,0 +1,92 @@
+"""Tests for the structured, comment-preserving config writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from qracer.config import writer
+
+
+class TestConfigValue:
+    def test_seeds_from_template_and_preserves_comments(self, tmp_path: Path) -> None:
+        writer.set_config_value("max_iterations", 7, config_dir=tmp_path)
+        text = (tmp_path / "config.toml").read_text(encoding="utf-8")
+        assert "max_iterations = 7" in text
+        assert "# Analysis loop tuning" in text  # template comment preserved
+        assert 'default_mode = "quick"' in text  # untouched key survives
+
+    def test_sets_nested_briefing_key(self, tmp_path: Path) -> None:
+        writer.set_config_value("briefing.schedule", "0 9 * * *", config_dir=tmp_path)
+        text = (tmp_path / "config.toml").read_text(encoding="utf-8")
+        assert "[briefing]" in text
+        assert 'schedule = "0 9 * * *"' in text
+        assert "top_n = 5" in text  # other briefing keys intact
+
+    def test_types_serialize_correctly(self, tmp_path: Path) -> None:
+        writer.set_config_value("autonomous_enabled", False, config_dir=tmp_path)
+        writer.set_config_value("confidence_threshold", 0.85, config_dir=tmp_path)
+        text = (tmp_path / "config.toml").read_text(encoding="utf-8")
+        assert "autonomous_enabled = false" in text
+        assert "confidence_threshold = 0.85" in text
+
+
+class TestPortfolioValue:
+    def test_sets_currency_and_nested_limit(self, tmp_path: Path) -> None:
+        writer.set_portfolio_value("currency", "KRW", config_dir=tmp_path)
+        writer.set_portfolio_value("limits.max_sector_pct", 55.0, config_dir=tmp_path)
+        text = (tmp_path / "portfolio.toml").read_text(encoding="utf-8")
+        assert 'currency = "KRW"' in text
+        assert "max_sector_pct = 55.0" in text
+
+
+class TestProviderField:
+    def test_enables_existing_block_preserving_others(self, tmp_path: Path) -> None:
+        writer.set_provider_field("dart", "enabled", True, config_dir=tmp_path)
+        text = (tmp_path / "providers.toml").read_text(encoding="utf-8")
+        assert "[providers.dart]" in text
+        dart_block = text.split("[providers.dart]", 1)[1].split("[providers.")[0]
+        assert "enabled = true" in dart_block
+        assert 'api_key_env = "DART_API_KEY"' in dart_block  # schema field preserved
+        assert "[providers.yfinance]" in text  # other providers untouched
+
+    def test_creates_missing_block_from_schema(self, tmp_path: Path) -> None:
+        # A providers.toml that lacks the dart block entirely.
+        (tmp_path / "providers.toml").write_text(
+            '[providers.yfinance]\nenabled = true\nkind = "data"\n', encoding="utf-8"
+        )
+        writer.set_provider_field("dart", "enabled", True, config_dir=tmp_path)
+        text = (tmp_path / "providers.toml").read_text(encoding="utf-8")
+        assert "[providers.dart]" in text
+        assert "enabled = true" in text.split("[providers.dart]", 1)[1]
+
+
+class TestCredentials:
+    def test_upsert_and_read(self, tmp_path: Path) -> None:
+        writer.set_credential("DART_API_KEY", "abc", config_dir=tmp_path)
+        writer.set_credential("DART_API_KEY", "xyz", config_dir=tmp_path)  # update in place
+        writer.set_credential("FINNHUB_API_KEY", "fk", config_dir=tmp_path)
+        assert writer.read_credentials(config_dir=tmp_path) == {
+            "DART_API_KEY": "xyz",
+            "FINNHUB_API_KEY": "fk",
+        }
+
+    def test_preserves_comments_and_blank_lines(self, tmp_path: Path) -> None:
+        (tmp_path / "credentials.env").write_text("# my keys\nEXISTING=1\n", encoding="utf-8")
+        writer.set_credential("NEW_KEY", "2", config_dir=tmp_path)
+        text = (tmp_path / "credentials.env").read_text(encoding="utf-8")
+        assert "# my keys" in text
+        assert "EXISTING=1" in text
+        assert "NEW_KEY=2" in text
+
+    def test_unset(self, tmp_path: Path) -> None:
+        writer.set_credential("A", "1", config_dir=tmp_path)
+        writer.set_credential("B", "2", config_dir=tmp_path)
+        writer.unset_credential("A", config_dir=tmp_path)
+        assert writer.read_credentials(config_dir=tmp_path) == {"B": "2"}
+
+    def test_unset_missing_is_noop(self, tmp_path: Path) -> None:
+        writer.unset_credential("NOPE", config_dir=tmp_path)  # no file yet
+        assert writer.read_credentials(config_dir=tmp_path) == {}
+
+    def test_read_missing_returns_empty(self, tmp_path: Path) -> None:
+        assert writer.read_credentials(config_dir=tmp_path) == {}

--- a/tests/web/test_settings_ui.py
+++ b/tests/web/test_settings_ui.py
@@ -1,0 +1,72 @@
+"""Unit tests for the web Settings section's pure apply helpers (no NiceGUI)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from qracer.config import settings_schema as ss  # noqa: E402
+from qracer.web import settings_ui  # noqa: E402
+
+
+class TestCoerceWidget:
+    def test_int_from_number_float(self) -> None:
+        assert settings_ui._coerce_widget(ss.require("max_iterations"), 9.0) == 9
+
+    def test_bool(self) -> None:
+        assert settings_ui._coerce_widget(ss.require("autonomous_enabled"), True) is True
+
+    def test_str_from_none(self) -> None:
+        assert settings_ui._coerce_widget(ss.require("briefing.timezone"), None) == ""
+
+
+class TestApplyScalar:
+    def test_writes_config_target(self, tmp_path: Path) -> None:
+        stored = settings_ui.apply_scalar(ss.require("max_iterations"), 7.0, config_dir=tmp_path)
+        assert stored == 7
+        assert "max_iterations = 7" in (tmp_path / "config.toml").read_text(encoding="utf-8")
+
+    def test_writes_nested_config_target(self, tmp_path: Path) -> None:
+        settings_ui.apply_scalar(ss.require("briefing.schedule"), "0 9 * * *", config_dir=tmp_path)
+        text = (tmp_path / "config.toml").read_text(encoding="utf-8")
+        assert "[briefing]" in text and 'schedule = "0 9 * * *"' in text
+
+    def test_writes_portfolio_target(self, tmp_path: Path) -> None:
+        settings_ui.apply_scalar(ss.require("currency"), "KRW", config_dir=tmp_path)
+        assert 'currency = "KRW"' in (tmp_path / "portfolio.toml").read_text(encoding="utf-8")
+
+    def test_invalid_choice_raises_and_does_not_write(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="must be one of"):
+            settings_ui.apply_scalar(ss.require("default_mode"), "sideways", config_dir=tmp_path)
+        assert not (tmp_path / "config.toml").exists()
+
+    def test_invalid_cron_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid cron"):
+            settings_ui.apply_scalar(ss.require("briefing.schedule"), "nope", config_dir=tmp_path)
+
+
+class TestApplyProvider:
+    def test_enables_sets_priority_and_key(self, tmp_path: Path) -> None:
+        settings_ui.apply_provider("dart", True, 40, "DART_API_KEY", "MYKEY", config_dir=tmp_path)
+        providers = (tmp_path / "providers.toml").read_text(encoding="utf-8")
+        dart = providers.split("[providers.dart]", 1)[1]
+        assert "enabled = true" in dart
+        assert "priority = 40" in dart
+        from qracer.config import writer
+
+        assert writer.read_credentials(config_dir=tmp_path) == {"DART_API_KEY": "MYKEY"}
+
+    def test_blank_key_leaves_credentials_untouched(self, tmp_path: Path) -> None:
+        settings_ui.apply_provider("dart", False, 40, "DART_API_KEY", "", config_dir=tmp_path)
+        from qracer.config import writer
+
+        assert writer.read_credentials(config_dir=tmp_path) == {}
+        dart = (
+            (tmp_path / "providers.toml")
+            .read_text(encoding="utf-8")
+            .split("[providers.dart]", 1)[1]
+        )
+        assert "enabled = false" in dart

--- a/tests/web/test_settings_ui.py
+++ b/tests/web/test_settings_ui.py
@@ -47,6 +47,40 @@ class TestApplyScalar:
         with pytest.raises(ValueError, match="Invalid cron"):
             settings_ui.apply_scalar(ss.require("briefing.schedule"), "nope", config_dir=tmp_path)
 
+    def test_blank_numeric_raises_valueerror_not_typeerror(self, tmp_path: Path) -> None:
+        # A cleared ui.number yields None; must surface as ValueError, not TypeError.
+        with pytest.raises(ValueError, match="must be a number"):
+            settings_ui.apply_scalar(ss.require("max_iterations"), None, config_dir=tmp_path)
+
+
+class TestApplyGroup:
+    def test_writes_all_when_valid(self, tmp_path: Path) -> None:
+        items = [
+            (ss.require("briefing.top_n"), 9.0),
+            (ss.require("briefing.schedule"), "0 9 * * *"),
+        ]
+        settings_ui.apply_group(items, config_dir=tmp_path)
+        text = (tmp_path / "config.toml").read_text(encoding="utf-8")
+        assert "top_n = 9" in text and 'schedule = "0 9 * * *"' in text
+
+    def test_atomic_no_partial_write_on_validation_error(self, tmp_path: Path) -> None:
+        # Second item is invalid; nothing (not even the valid first item) is written.
+        items = [
+            (ss.require("briefing.top_n"), 7),
+            (ss.require("briefing.schedule"), "not a cron"),
+        ]
+        with pytest.raises(ValueError, match="Invalid cron"):
+            settings_ui.apply_group(items, config_dir=tmp_path)
+        assert not (tmp_path / "config.toml").exists()
+
+
+class TestApplyProviderValidation:
+    def test_blank_priority_raises_and_writes_nothing(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Priority must be a number"):
+            settings_ui.apply_provider("dart", True, None, "DART_API_KEY", "K", config_dir=tmp_path)
+        assert not (tmp_path / "providers.toml").exists()
+        assert not (tmp_path / "credentials.env").exists()
+
 
 class TestApplyProvider:
     def test_enables_sets_priority_and_key(self, tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2241,6 +2241,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "textual" },
+    { name = "tomlkit" },
     { name = "yfinance" },
 ]
 
@@ -2307,6 +2308,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "textual", specifier = ">=0.70.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
+    { name = "tomlkit", specifier = ">=0.13.0" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.24.0" },
     { name = "yfinance", specifier = ">=0.2.0" },
 ]
@@ -2455,6 +2457,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Configuration was scattered across four files and only editable by hand or a fragile wizard: `qracer install` used regex/string substitution and `config --set` used a flat writer that **destroyed nested tables** (`[briefing]`, `[providers.*]`, `[[holdings]]`). The dashboard had no settings editing. Adding DART exposed the pain — data-provider keys had to be hand-added to `credentials.env` and enabled by hand-toggling `providers.toml`.

This adds one declarative schema rendered by both front-ends over one structured writer.

## Layers
- **`config/writer.py`** — the single write path. `tomlkit` round-trip edits that preserve comments, formatting, and nested tables, plus a `credentials.env` upsert. Targets `QRACER_CONFIG_DIR` if set, else `~/.qracer/`, so reads and writes stay consistent.
- **`config/settings_schema.py`** — each editable setting declared once (`Setting`: key, target, group, kind, choices, validator) plus provider rows derived from the catalog + current config. Add a setting here → it appears in both front-ends.
- **CLI**: `qracer config` gains a grouped listing and `get`/`set`/`providers` subcommands (schema-validated); `config providers` enables a provider and sets its API key in one interactive flow — the DART fix. `--set key=value` stays for compatibility. `install` now builds on the writer (regex helpers removed).
- **Web**: a new editable **Settings** tab (`web/settings_ui.py`) renders the schema as grouped forms + a Providers group with masked, write-only API-key inputs, saving through the same writer. Verified end-to-end via Playwright (render + live save).

`tomlkit` added as a core dependency.

## Code review (2 reviewers) → fixed before merge
- **Critical**: credentials read/write mismatch under `QRACER_CONFIG_DIR` (writer wrote there, loader read `~/.qracer` only → key silently ignored). Loader now resolves credentials the same way; regression test round-trips a CLI-set key through `load_config()`.
- **Important**: `install` re-run now applies the wizard's choice to existing files via surgical upserts (no more misleading "Setup complete"); web group Save is atomic (validate-all-then-write, no partial saves); blank numeric fields raise a clean `ValueError` instead of an uncaught `TypeError`.
- **Minor**: `_set_dotted` scalar-collision guard; `read_credentials` uses `dotenv_values` for loader parity; new provider blocks keep schema comments; int widget stepping; `config --set` rejects a trailing subcommand.

## Tests / quality
Writer (round-trip, nesting, credentials), schema (coerce/validate/provider derivation), CLI subcommands (isolated via `QRACER_CONFIG_DIR`), and web apply helpers (atomicity, blank-numeric). pyright 0 errors, ruff/docs clean, coverage gate met (~81%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)