### PR TITLE
refactor(phase0): green the test suite + shared fixtures + coverage config

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,7 +48,8 @@ jobs:
         run: uv sync --extra web
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=qracer --cov-report=term-missing --cov-fail-under=80 --ignore=tests/memory/test_memory_searcher.py -k "not TestEmbeddingSearch"
+        # Coverage threshold + reporting come from [tool.coverage.*] in pyproject.toml.
+        run: uv run pytest --cov=qracer --ignore=tests/memory/test_memory_searcher.py -k "not TestEmbeddingSearch"
 
       - name: Upload coverage report
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,13 @@ reportMissingTypeStubs = false
 testpaths = ["tests"]
 asyncio_mode = "auto"
 pythonpath = [".", "tests"]
+
+# Coverage config lives here (not just in CI) so a local `pytest --cov=qracer`
+# enforces the same gate. `--cov` is intentionally NOT in addopts, so running a
+# subset of tests stays fast and doesn't trip fail_under.
+[tool.coverage.run]
+source = ["qracer"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/qracer/dashboard/panels.py
+++ b/qracer/dashboard/panels.py
@@ -522,7 +522,7 @@ class HistoryPanel(VerticalScroll):
             sid = f.stem
             mtime = f.stat().st_mtime
             dt = datetime.datetime.fromtimestamp(mtime)
-            line_count = sum(1 for _ in f.open())
+            line_count = sum(1 for _ in f.open(encoding="utf-8"))
             table.add_row(sid, dt.strftime("%Y-%m-%d %H:%M"), str(line_count))
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -192,78 +192,61 @@ class TestStatus:
 
 
 class TestConfig:
-    """The `config` command is isolated via QRACER_CONFIG_DIR, which both the
-    loader (reads) and the writer (writes) honor."""
+    """The `config` command is isolated via the shared ``config_dir`` fixture, which
+    sets QRACER_CONFIG_DIR (honored by both the loader and the writer)."""
 
-    def _env(self, monkeypatch, tmp_path: Path) -> Path:
-        d = tmp_path / ".qracer"
-        d.mkdir()
-        monkeypatch.setenv("QRACER_CONFIG_DIR", str(d))
-        return d
-
-    def test_config_show_lists_groups_and_providers(self, monkeypatch, tmp_path: Path) -> None:
-        self._env(monkeypatch, tmp_path)
+    def test_config_show_lists_groups_and_providers(self, config_dir: Path) -> None:
         result = CliRunner().invoke(main, ["config"])
         assert result.exit_code == 0
         assert "General:" in result.output
         assert "default_mode" in result.output
         assert "Providers:" in result.output
 
-    def test_config_set_nested_and_seeds_file(self, monkeypatch, tmp_path: Path) -> None:
-        d = self._env(monkeypatch, tmp_path)  # no config.toml yet
+    def test_config_set_nested_and_seeds_file(self, config_dir: Path) -> None:
         result = CliRunner().invoke(main, ["config", "set", "briefing.schedule", "0 9 * * *"])
         assert result.exit_code == 0, result.output
         assert "Set briefing.schedule = 0 9 * * *" in result.output
-        text = (d / "config.toml").read_text(encoding="utf-8")
+        text = (config_dir / "config.toml").read_text(encoding="utf-8")
         assert "[briefing]" in text and 'schedule = "0 9 * * *"' in text
 
-    def test_config_set_compat_flag(self, monkeypatch, tmp_path: Path) -> None:
-        d = self._env(monkeypatch, tmp_path)
+    def test_config_set_compat_flag(self, config_dir: Path) -> None:
         result = CliRunner().invoke(main, ["config", "--set", "default_mode=deep"])
         assert result.exit_code == 0
-        assert 'default_mode = "deep"' in (d / "config.toml").read_text(encoding="utf-8")
+        assert 'default_mode = "deep"' in (config_dir / "config.toml").read_text(encoding="utf-8")
 
-    def test_config_get(self, monkeypatch, tmp_path: Path) -> None:
-        self._env(monkeypatch, tmp_path)
+    def test_config_get(self, config_dir: Path) -> None:
         CliRunner().invoke(main, ["config", "set", "max_iterations", "9"])
         result = CliRunner().invoke(main, ["config", "get", "max_iterations"])
         assert result.exit_code == 0
         assert result.output.strip() == "9"
 
-    def test_config_set_invalid_choice(self, monkeypatch, tmp_path: Path) -> None:
-        self._env(monkeypatch, tmp_path)
+    def test_config_set_invalid_choice(self, config_dir: Path) -> None:
         result = CliRunner().invoke(main, ["config", "set", "default_mode", "sideways"])
         assert result.exit_code != 0
         assert "must be one of" in result.output
 
-    def test_config_set_unknown_key(self, monkeypatch, tmp_path: Path) -> None:
-        self._env(monkeypatch, tmp_path)
+    def test_config_set_unknown_key(self, config_dir: Path) -> None:
         result = CliRunner().invoke(main, ["config", "set", "bogus", "1"])
         assert result.exit_code != 0
         assert "Unknown setting" in result.output
 
-    def test_config_set_bad_compat_format(self, monkeypatch, tmp_path: Path) -> None:
-        self._env(monkeypatch, tmp_path)
+    def test_config_set_bad_compat_format(self, config_dir: Path) -> None:
         result = CliRunner().invoke(main, ["config", "--set", "noequals"])
         assert result.exit_code != 0
 
-    def test_config_providers_enables_and_sets_key(self, monkeypatch, tmp_path: Path) -> None:
-        d = self._env(monkeypatch, tmp_path)
+    def test_config_providers_enables_and_sets_key(self, config_dir: Path) -> None:
         # Configure 'dart': enable = yes, enter a key, then blank to finish.
         result = CliRunner().invoke(main, ["config", "providers"], input="dart\ny\nMY_DART_KEY\n\n")
         assert result.exit_code == 0, result.output
-        providers = (d / "providers.toml").read_text(encoding="utf-8")
+        providers = (config_dir / "providers.toml").read_text(encoding="utf-8")
         assert "[providers.dart]" in providers
         assert "enabled = true" in providers.split("[providers.dart]", 1)[1]
-        creds = (d / "credentials.env").read_text(encoding="utf-8")
+        creds = (config_dir / "credentials.env").read_text(encoding="utf-8")
         assert "DART_API_KEY=MY_DART_KEY" in creds
 
-    def test_provider_key_round_trips_through_load_config(
-        self, monkeypatch, tmp_path: Path
-    ) -> None:
+    def test_provider_key_round_trips_through_load_config(self, config_dir: Path) -> None:
         # Regression: a key set via the CLI under QRACER_CONFIG_DIR must actually be
         # read back by load_config() (writer and loader must resolve the same dir).
-        self._env(monkeypatch, tmp_path)
         CliRunner().invoke(main, ["config", "providers"], input="dart\ny\nROUNDTRIP\n\n")
         from qracer.config.loader import load_config
 

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -122,7 +123,8 @@ class TestTomlParseErrors:
     def test_error_message_includes_path(self, tmp_path: Path) -> None:
         toml_file = tmp_path / "bad.toml"
         toml_file.write_text("= no key\n")
-        with pytest.raises(ConfigParseError, match=str(toml_file)):
+        # re.escape: a Windows path (e.g. C:\Users\...) is not a valid regex on its own.
+        with pytest.raises(ConfigParseError, match=re.escape(str(toml_file))):
             _load_toml(toml_file)
 
     def test_error_chains_original_exception(self, tmp_path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,48 @@
-"""Root conftest — makes the tests/ directory importable for shared helpers."""
+"""Root conftest — makes the tests/ directory importable and provides shared fixtures.
+
+Fixtures here DRY setup that was previously hand-rolled per test file: an isolated
+config directory (honored by both the loader and the writer via ``QRACER_CONFIG_DIR``)
+and the fake data/LLM registries from :mod:`tests.helpers`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """An isolated ``~/.qracer``-style dir wired via ``QRACER_CONFIG_DIR``.
+
+    Both the loader (reads) and the writer (writes) resolve to this directory, and
+    the loader's mtime-cached singleton is reset so each test sees a clean load.
+    """
+    d = tmp_path / ".qracer"
+    d.mkdir()
+    monkeypatch.setenv("QRACER_CONFIG_DIR", str(d))
+
+    from qracer.config import loader
+
+    monkeypatch.setattr(loader, "_cached_config", None, raising=False)
+    monkeypatch.setattr(loader, "_config_mtimes", {}, raising=False)
+    yield d
+
+
+@pytest.fixture
+def data_registry():
+    """A DataRegistry preloaded with the fake price/fundamental/macro/news adapters."""
+    from tests.helpers import make_data_registry
+
+    return make_data_registry()
+
+
+@pytest.fixture
+def llm_registry():
+    """An LLMRegistry backed by a FakeLLM (returns ``[]`` by default)."""
+    from tests.helpers import make_llm_registry
+
+    registry, _fake = make_llm_registry()
+    return registry

--- a/tests/conversation/test_quickpath.py
+++ b/tests/conversation/test_quickpath.py
@@ -184,7 +184,7 @@ class TestKeywordDetection:
 
         import asyncio
 
-        intent = asyncio.get_event_loop().run_until_complete(parser.parse("What's AAPL at?"))
+        intent = asyncio.run(parser.parse("What's AAPL at?"))
         assert intent.intent_type == IntentType.PRICE_CHECK
 
     def test_quick_news_keywords(self) -> None:
@@ -202,7 +202,7 @@ class TestKeywordDetection:
 
         import asyncio
 
-        intent = asyncio.get_event_loop().run_until_complete(parser.parse("Any news on TSLA?"))
+        intent = asyncio.run(parser.parse("Any news on TSLA?"))
         assert intent.intent_type == IntentType.QUICK_NEWS
 
 

--- a/tests/conversation/test_report_exporter.py
+++ b/tests/conversation/test_report_exporter.py
@@ -71,7 +71,7 @@ class TestReportExporterMarkdown:
         path = exporter.save_markdown(_intent(), _analysis(), "Analysis text here.")
         assert path.exists()
         assert path.suffix == ".md"
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
         assert "AAPL" in content
         assert "Analysis text here." in content
         assert "0.85" in content
@@ -79,7 +79,7 @@ class TestReportExporterMarkdown:
     def test_save_with_thesis(self, tmp_path) -> None:
         exporter = ReportExporter(tmp_path)
         path = exporter.save_markdown(_intent(), _analysis(with_thesis=True), "Response")
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
         assert "Trade Thesis" in content
         assert "$175.00" in content
         assert "$200.00" in content
@@ -90,7 +90,7 @@ class TestReportExporterMarkdown:
     def test_save_with_data_sources(self, tmp_path) -> None:
         exporter = ReportExporter(tmp_path)
         path = exporter.save_markdown(_intent(), _analysis(), "Response")
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
         assert "Data Sources" in content
         assert "price_event" in content
         assert "news" in content
@@ -110,7 +110,7 @@ class TestReportExporterJson:
         path = exporter.save_json(_intent(), _analysis(), "Analysis text.")
         assert path.exists()
         assert path.suffix == ".json"
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert data["ticker"] == "AAPL"
         assert data["confidence"] == 0.85
         assert data["response"] == "Analysis text."
@@ -119,7 +119,7 @@ class TestReportExporterJson:
     def test_save_with_thesis(self, tmp_path) -> None:
         exporter = ReportExporter(tmp_path)
         path = exporter.save_json(_intent(), _analysis(with_thesis=True), "Response")
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert "trade_thesis" in data
         assert data["trade_thesis"]["conviction"] == 8
         assert data["trade_thesis"]["target_price"] == 200.0
@@ -127,7 +127,7 @@ class TestReportExporterJson:
     def test_no_thesis_key_when_none(self, tmp_path) -> None:
         exporter = ReportExporter(tmp_path)
         path = exporter.save_json(_intent(), _analysis(with_thesis=False), "Response")
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert "trade_thesis" not in data
 
 


### PR DESCRIPTION
**Phase 0 of the phased code-quality refactor** (approved plan). A safety net so the later structural phases have a trustworthy regression gate. Behavior-preserving.

## Fixes the 4 long-standing "known failures"
All were cross-platform **test** bugs, not product bugs:
- `test_loader`: `match=str(path)` used an unescaped Windows path as a regex (`\U` from `\Users`) → `re.escape`.
- `test_report_exporter`: `path.read_text()` without encoding hit cp949 on an em-dash → read utf-8.
- `test_quickpath` (×2): `asyncio.get_event_loop().run_until_complete(...)` errors on 3.12+ with no running loop → `asyncio.run(...)`.

## One real production bug
`dashboard/panels.py` counted session-file lines via `f.open()` with no encoding — locale-dependent (cp949 decode error on non-ASCII session files). Now `encoding="utf-8"`.

## Shared fixtures (DRY the per-file setup)
`tests/conftest.py` (was a 1-line stub) now provides `config_dir` (isolated `QRACER_CONFIG_DIR` + loader-cache reset), `data_registry`, `llm_registry`. Adopted `config_dir` in the CLI config tests, removing their per-file `_env` helper.

## Coverage config → pyproject
Threshold + reporting moved into `[tool.coverage.*]` so a local `pytest --cov=qracer` enforces the same 80% gate as CI (kept out of `addopts` so single-file runs stay fast). CI command simplified.

## Result
Whole suite green — **954 passed, 0 failed** — matching Linux CI. pyright 0 errors, ruff/docs clean, coverage 81%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)