### PR TITLE
refactor(phase1): DRY — JsonListStore, shared fetch_prices, PollingMonitor

### DIFF
--- a/qracer/agent_monitor.py
+++ b/qracer/agent_monitor.py
@@ -14,18 +14,18 @@ UI to display.
 from __future__ import annotations
 
 import logging
-import time
 
 from qracer.agent_runner import AgentResult, run_agents
 from qracer.agents_store import CONTINUOUS_COOLDOWN_SECONDS, AgentStore
 from qracer.llm.providers import LLMProvider
+from qracer.monitors.base import PollingMonitor
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_CHECK_INTERVAL = 5.0  # seconds between agent-due checks
 
 
-class AgentMonitor:
+class AgentMonitor(PollingMonitor):
     """Runs due custom agents concurrently and stores their results.
 
     Usage::
@@ -43,25 +43,18 @@ class AgentMonitor:
         check_interval: float = DEFAULT_CHECK_INTERVAL,
         continuous_cooldown: int = CONTINUOUS_COOLDOWN_SECONDS,
     ) -> None:
+        super().__init__(check_interval)
         self._store = store
         self._provider = provider
-        self._check_interval = check_interval
         self._continuous_cooldown = continuous_cooldown
-        self._last_check: float | None = None
 
     @property
     def store(self) -> AgentStore:
         return self._store
 
-    def should_check(self) -> bool:
-        """Return True when a due-check is warranted (monotonic throttle)."""
-        if self._last_check is None:
-            return True
-        return (time.monotonic() - self._last_check) >= self._check_interval
-
     async def check(self) -> list[AgentResult]:
         """Run all due agents concurrently and persist their results."""
-        self._last_check = time.monotonic()
+        self._mark_checked()
         due = self._store.due(continuous_cooldown=self._continuous_cooldown)
         if not due:
             return []

--- a/qracer/agents_store.py
+++ b/qracer/agents_store.py
@@ -12,16 +12,16 @@ UI can share the same file and see each other's writes.
 
 from __future__ import annotations
 
-import json
 import logging
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from pathlib import Path
 from typing import Any, cast
 
 from croniter import croniter
+
+from qracer.storage.json_store import JsonListStore
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class Agent:
         return f"{self.name} [{self.model}] ({trigger})"
 
 
-class AgentStore:
+class AgentStore(JsonListStore[Agent]):
     """File-backed storage for custom agents.
 
     Usage::
@@ -120,26 +120,23 @@ class AgentStore:
         store.record_run(agent.id, output="...")
     """
 
-    def __init__(self, path: Path) -> None:
-        self._path = path
-        self._mtime: float = 0.0
-        self._agents: list[Agent] = self._load()
+    _label = "agents"
 
     @property
     def agents(self) -> list[Agent]:
         """All agents in stored order."""
         self._maybe_reload()
-        return list(self._agents)
+        return list(self._items)
 
     def get(self, agent_id: str) -> Agent | None:
         self._maybe_reload()
-        return next((a for a in self._agents if a.id == agent_id), None)
+        return next((a for a in self._items if a.id == agent_id), None)
 
     def find_by_name(self, name: str) -> Agent | None:
         """Case-insensitive lookup by name."""
         self._maybe_reload()
         lowered = name.strip().lower()
-        return next((a for a in self._agents if a.name.lower() == lowered), None)
+        return next((a for a in self._items if a.name.lower() == lowered), None)
 
     def create(
         self,
@@ -169,7 +166,7 @@ class AgentStore:
             created_at=now.isoformat(),
             next_run_at=next_run,
         )
-        self._agents.append(agent)
+        self._items.append(agent)
         self._save()
         return agent
 
@@ -178,7 +175,7 @@ class AgentStore:
 
         Recomputes ``next_run_at`` whenever the trigger/cron changes.
         """
-        agent = next((a for a in self._agents if a.id == agent_id), None)
+        agent = next((a for a in self._items if a.id == agent_id), None)
         if agent is None:
             return None
 
@@ -211,9 +208,9 @@ class AgentStore:
 
     def remove(self, agent_id: str) -> bool:
         """Remove an agent by id. Returns True if found and removed."""
-        for i, a in enumerate(self._agents):
+        for i, a in enumerate(self._items):
             if a.id == agent_id:
-                self._agents.pop(i)
+                self._items.pop(i)
                 self._save()
                 return True
         return False
@@ -221,8 +218,8 @@ class AgentStore:
     def reorder(self, ids: list[str]) -> None:
         """Reorder agents to match *ids*; any not listed keep their relative order at the end."""
         index = {aid: pos for pos, aid in enumerate(ids)}
-        original = {a.id: i for i, a in enumerate(self._agents)}
-        self._agents.sort(key=lambda a: index.get(a.id, len(index) + original[a.id]))
+        original = {a.id: i for i, a in enumerate(self._items)}
+        self._items.sort(key=lambda a: index.get(a.id, len(index) + original[a.id]))
         self._save()
 
     def due(
@@ -234,7 +231,7 @@ class AgentStore:
         """Return agents that should run now (cron due or continuous off cooldown)."""
         self._maybe_reload()
         ref = now or datetime.now(timezone.utc)
-        return [a for a in self._agents if a.is_due(ref, continuous_cooldown=continuous_cooldown)]
+        return [a for a in self._items if a.is_due(ref, continuous_cooldown=continuous_cooldown)]
 
     def record_run(
         self,
@@ -244,7 +241,7 @@ class AgentStore:
         error: str | None = None,
     ) -> bool:
         """Persist the result of a run and advance the schedule. Returns True if found."""
-        for a in self._agents:
+        for a in self._items:
             if a.id != agent_id:
                 continue
             now = datetime.now(timezone.utc)
@@ -259,51 +256,17 @@ class AgentStore:
         return False
 
     def clear(self) -> None:
-        self._agents.clear()
+        self._items.clear()
         self._save()
-
-    def __len__(self) -> int:
-        return len(self._agents)
 
     # -- persistence --------------------------------------------------------
 
-    def _maybe_reload(self) -> None:
-        """Re-read from disk if another process modified the file."""
-        if not self._path.exists():
-            return
-        try:
-            current_mtime = self._path.stat().st_mtime
-        except OSError:
-            return
-        if current_mtime != self._mtime:
-            self._agents = self._load()
-
-    def _load(self) -> list[Agent]:
-        if not self._path.exists():
-            return []
-        try:
-            data = json.loads(self._path.read_text(encoding="utf-8"))
-            self._mtime = self._path.stat().st_mtime
-            if isinstance(data, list):
-                return [self._deserialize(item) for item in data if isinstance(item, dict)]
-        except (json.JSONDecodeError, OSError, KeyError, ValueError):
-            logger.warning("Failed to load agents from %s", self._path)
-        return []
-
-    def _save(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        data = [self._serialize(a) for a in self._agents]
-        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        self._mtime = self._path.stat().st_mtime
-
-    @staticmethod
-    def _serialize(agent: Agent) -> dict[str, Any]:
+    def _serialize(self, agent: Agent) -> dict[str, Any]:
         d = asdict(agent)
         d["trigger_type"] = agent.trigger_type.value
         return d
 
-    @staticmethod
-    def _deserialize(data: dict[str, Any]) -> Agent:
+    def _deserialize(self, data: dict[str, Any]) -> Agent:
         return Agent(
             id=data["id"],
             name=data["name"],

--- a/qracer/alert_monitor.py
+++ b/qracer/alert_monitor.py
@@ -7,11 +7,11 @@ PriceProvider capability. Designed to be called from the REPL heartbeat.
 from __future__ import annotations
 
 import logging
-import time
 
 from qracer.alerts import AlertResult, AlertStore
 from qracer.data.providers import PriceProvider
 from qracer.data.registry import DataRegistry
+from qracer.monitors.base import PollingMonitor
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_CHECK_INTERVAL = 5
 
 
-class AlertMonitor:
+class AlertMonitor(PollingMonitor):
     """Monitors active alerts and triggers them when conditions are met.
 
     Usage::
@@ -36,27 +36,20 @@ class AlertMonitor:
         data_registry: DataRegistry,
         check_interval: float = DEFAULT_CHECK_INTERVAL,
     ) -> None:
+        super().__init__(check_interval)
         self._store = store
         self._data_registry = data_registry
-        self._check_interval = check_interval
-        self._last_check: float | None = None
 
     @property
     def store(self) -> AlertStore:
         return self._store
-
-    def should_check(self) -> bool:
-        """Return True if enough time has elapsed since the last check."""
-        if self._last_check is None:
-            return True
-        return (time.monotonic() - self._last_check) >= self._check_interval
 
     async def check(self) -> list[AlertResult]:
         """Evaluate all active alerts and return any that triggered.
 
         Triggered alerts are automatically marked inactive in the store.
         """
-        self._last_check = time.monotonic()
+        self._mark_checked()
         active = self._store.get_active()
         if not active:
             return []

--- a/qracer/alerts.py
+++ b/qracer/alerts.py
@@ -5,14 +5,14 @@ Persisted as ``alerts.json`` in the user's ``~/.qracer/`` directory.
 
 from __future__ import annotations
 
-import json
 import logging
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from pathlib import Path
 from typing import Any
+
+from qracer.storage.json_store import JsonListStore
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class AlertResult:
     message: str
 
 
-class AlertStore:
+class AlertStore(JsonListStore[Alert]):
     """File-backed storage for price alerts.
 
     Usage::
@@ -87,16 +87,13 @@ class AlertStore:
         store.mark_triggered(alert.id)
     """
 
-    def __init__(self, path: Path) -> None:
-        self._path = path
-        self._mtime: float = 0.0
-        self._alerts: list[Alert] = self._load()
+    _label = "alerts"
 
     @property
     def alerts(self) -> list[Alert]:
         """All alerts."""
         self._maybe_reload()
-        return list(self._alerts)
+        return list(self._items)
 
     def create(
         self,
@@ -113,35 +110,24 @@ class AlertStore:
             threshold=threshold,
             created_at=datetime.now(timezone.utc).isoformat(),
         )
-        self._alerts.append(alert)
+        self._items.append(alert)
         self._save()
         return alert
-
-    def _maybe_reload(self) -> None:
-        """Re-read from disk if another process modified the file."""
-        if not self._path.exists():
-            return
-        try:
-            current_mtime = self._path.stat().st_mtime
-        except OSError:
-            return
-        if current_mtime != self._mtime:
-            self._alerts = self._load()
 
     def get_active(self) -> list[Alert]:
         """Return all active (not yet triggered) alerts."""
         self._maybe_reload()
-        return [a for a in self._alerts if a.active]
+        return [a for a in self._items if a.active]
 
     def get_by_ticker(self, ticker: str) -> list[Alert]:
         """Return all alerts for a given ticker."""
         self._maybe_reload()
         upper = ticker.upper()
-        return [a for a in self._alerts if a.ticker == upper]
+        return [a for a in self._items if a.ticker == upper]
 
     def mark_triggered(self, alert_id: str, price: float | None = None) -> bool:
         """Mark an alert as triggered. Returns True if found and updated."""
-        for alert in self._alerts:
+        for alert in self._items:
             if alert.id == alert_id and alert.active:
                 alert.active = False
                 alert.triggered_at = datetime.now(timezone.utc).isoformat()
@@ -151,47 +137,24 @@ class AlertStore:
 
     def remove(self, alert_id: str) -> bool:
         """Remove an alert by ID. Returns True if found and removed."""
-        for i, alert in enumerate(self._alerts):
+        for i, alert in enumerate(self._items):
             if alert.id == alert_id:
-                self._alerts.pop(i)
+                self._items.pop(i)
                 self._save()
                 return True
         return False
 
     def clear(self) -> None:
         """Remove all alerts."""
-        self._alerts.clear()
+        self._items.clear()
         self._save()
 
-    def __len__(self) -> int:
-        return len(self._alerts)
-
-    def _load(self) -> list[Alert]:
-        if not self._path.exists():
-            return []
-        try:
-            data = json.loads(self._path.read_text(encoding="utf-8"))
-            self._mtime = self._path.stat().st_mtime
-            if isinstance(data, list):
-                return [self._deserialize(item) for item in data if isinstance(item, dict)]
-        except (json.JSONDecodeError, OSError, KeyError, ValueError):
-            logger.warning("Failed to load alerts from %s", self._path)
-        return []
-
-    def _save(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        data = [self._serialize(a) for a in self._alerts]
-        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        self._mtime = self._path.stat().st_mtime
-
-    @staticmethod
-    def _serialize(alert: Alert) -> dict[str, Any]:
+    def _serialize(self, alert: Alert) -> dict[str, Any]:
         d = asdict(alert)
         d["condition"] = alert.condition.value
         return d
 
-    @staticmethod
-    def _deserialize(data: dict[str, Any]) -> Alert:
+    def _deserialize(self, data: dict[str, Any]) -> Alert:
         return Alert(
             id=data["id"],
             ticker=data["ticker"],

--- a/qracer/autonomous.py
+++ b/qracer/autonomous.py
@@ -16,6 +16,7 @@ from zoneinfo import ZoneInfo
 
 from qracer.data.providers import NewsProvider, PriceProvider
 from qracer.data.registry import DataRegistry
+from qracer.monitors.base import PollingMonitor
 from qracer.watchlist import Watchlist
 
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ def _severity_for_pct(pct: float) -> Severity:
     return Severity.INFO
 
 
-class AutonomousMonitor:
+class AutonomousMonitor(PollingMonitor):
     """Monitors watchlist tickers for price moves and breaking news.
 
     Follows the same ``should_check()`` / ``check()`` polling pattern
@@ -99,12 +100,11 @@ class AutonomousMonitor:
         price_threshold_pct: float = DEFAULT_PRICE_THRESHOLD_PCT,
         cooldown_minutes: int = DEFAULT_COOLDOWN_MINUTES,
     ) -> None:
+        super().__init__(check_interval)
         self._watchlist = watchlist
         self._data = data_registry
-        self._check_interval = check_interval
         self._price_threshold_pct = price_threshold_pct
         self._cooldown_seconds = cooldown_minutes * 60
-        self._last_check: float | None = None
         # ticker → monotonic timestamp of last alert
         self._cooldowns: dict[str, float] = {}
         # ticker → last known price (for change detection)
@@ -114,13 +114,11 @@ class AutonomousMonitor:
         """Return True when a check is due and the market is open."""
         if not is_market_hours():
             return False
-        if self._last_check is None:
-            return True
-        return (time.monotonic() - self._last_check) >= self._check_interval
+        return super().should_check()
 
     async def check(self) -> list[AutonomousAlert]:
         """Scan watchlist tickers and return any triggered alerts."""
-        self._last_check = time.monotonic()
+        self._mark_checked()
         tickers = self._watchlist.tickers
         if not tickers:
             return []

--- a/qracer/briefing.py
+++ b/qracer/briefing.py
@@ -15,15 +15,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
 from croniter import croniter
 
-from qracer.data.providers import PriceProvider
+from qracer.data.prices import fetch_prices
 from qracer.llm.providers import CompletionRequest, Message, Role
+from qracer.monitors.base import PollingMonitor
 from qracer.notifications.providers import Notification, NotificationCategory
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ class BriefingComposer:
         watch = list(self._watchlist.tickers)
         all_tickers = list(dict.fromkeys([h.ticker for h in holdings] + watch))
 
-        prices = await self._fetch_prices(all_tickers)
+        prices = await fetch_prices(self._data, all_tickers)
 
         # Portfolio snapshot (fall back to avg_cost so the snapshot always builds).
         if holdings:
@@ -156,20 +156,6 @@ class BriefingComposer:
         state.news_lines = await self._news_lines(all_tickers[:_MAX_NEWS_TICKERS])
 
         return state
-
-    async def _fetch_prices(self, tickers: list[str]) -> dict[str, float]:
-        if not tickers:
-            return {}
-
-        async def one(ticker: str) -> tuple[str, float | None]:
-            try:
-                price = await self._data.async_get_with_fallback(PriceProvider, "get_price", ticker)
-                return ticker, float(price)
-            except Exception:  # noqa: BLE001 - best-effort per ticker
-                return ticker, None
-
-        results = await asyncio.gather(*(one(t) for t in tickers))
-        return {t: p for t, p in results if p is not None}
 
     def _thesis_lines(self) -> list[str]:
         assert self._fact_store is not None
@@ -225,7 +211,7 @@ class BriefingComposer:
         return response.content.strip()
 
 
-class BriefingScheduler:
+class BriefingScheduler(PollingMonitor):
     """Fires the composer once per scheduled cron occurrence and pushes the result."""
 
     def __init__(
@@ -237,14 +223,13 @@ class BriefingScheduler:
         timezone: "ZoneInfo | None" = None,
         check_interval: float = DEFAULT_CHECK_INTERVAL,
     ) -> None:
+        super().__init__(check_interval)
         # croniter raises on an invalid expression — validate eagerly.
         croniter(cron, self._now(timezone))
         self._composer = composer
         self._notifications = notifications
         self._cron = cron
         self._tz = timezone
-        self._check_interval = check_interval
-        self._last_check: float | None = None
         # Don't backfill on startup: only fire on the NEXT occurrence.
         self._last_slot: datetime = self._current_slot()
 
@@ -256,14 +241,9 @@ class BriefingScheduler:
         """Most recent scheduled datetime at or before now."""
         return croniter(self._cron, self._now(self._tz)).get_prev(datetime)
 
-    def should_check(self) -> bool:
-        if self._last_check is None:
-            return True
-        return (time.monotonic() - self._last_check) >= self._check_interval
-
     async def check(self) -> str | None:
         """If a scheduled slot has newly passed, compose and push the briefing."""
-        self._last_check = time.monotonic()
+        self._mark_checked()
         slot = self._current_slot()
         if slot == self._last_slot:
             return None

--- a/qracer/data/prices.py
+++ b/qracer/data/prices.py
@@ -1,0 +1,42 @@
+"""Shared best-effort price fetching.
+
+`fetch_prices` concurrently resolves the latest price for many tickers via the
+capability registry, skipping any that fail. Previously this exact ``asyncio.gather``
+loop was copy-pasted into the briefing composer and the web dashboard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from qracer.data.providers import PriceProvider
+
+if TYPE_CHECKING:
+    from qracer.data.registry import DataRegistry
+
+
+async def fetch_prices(
+    data_registry: "DataRegistry | None", tickers: list[str]
+) -> dict[str, float]:
+    """Return ``{ticker: price}`` for the tickers that resolve; skip failures.
+
+    Best-effort and concurrent: each ticker is fetched via the registry's
+    capability fallback, and any error (or a None registry / empty list) simply
+    omits that ticker from the result.
+    """
+    if data_registry is None or not tickers:
+        return {}
+
+    async def one(ticker: str) -> tuple[str, float | None]:
+        try:
+            price = await data_registry.async_get_with_fallback(PriceProvider, "get_price", ticker)
+            return ticker, float(price)
+        except Exception:  # noqa: BLE001 - best-effort per ticker
+            return ticker, None
+
+    results = await asyncio.gather(*(one(t) for t in tickers))
+    return {t: p for t, p in results if p is not None}
+
+
+__all__ = ["fetch_prices"]

--- a/qracer/monitors/__init__.py
+++ b/qracer/monitors/__init__.py
@@ -1,0 +1,1 @@
+"""Daemon polling monitors (shared base + throttling)."""

--- a/qracer/monitors/base.py
+++ b/qracer/monitors/base.py
@@ -1,0 +1,33 @@
+"""Shared base for the polling monitors run by the ``qracer serve`` tick loop.
+
+Every monitor (alerts, tasks, autonomous, agents, briefing) had a byte-identical
+monotonic-clock throttle. This collapses that into one base: subclasses call
+``super().__init__(check_interval)`` and stamp ``self._mark_checked()`` at the top
+of ``check()``. Override ``should_check`` to add extra gating (e.g. market hours),
+delegating to ``super().should_check()`` for the throttle.
+"""
+
+from __future__ import annotations
+
+import time
+
+
+class PollingMonitor:
+    """Monotonic-clock throttling for a ``should_check()`` / ``check()`` monitor."""
+
+    def __init__(self, check_interval: float) -> None:
+        self._check_interval = check_interval
+        self._last_check: float | None = None
+
+    def should_check(self) -> bool:
+        """True on the first call, then once per ``check_interval`` seconds."""
+        if self._last_check is None:
+            return True
+        return (time.monotonic() - self._last_check) >= self._check_interval
+
+    def _mark_checked(self) -> None:
+        """Record that a check just ran (call at the top of ``check()``)."""
+        self._last_check = time.monotonic()
+
+
+__all__ = ["PollingMonitor"]

--- a/qracer/storage/json_store.py
+++ b/qracer/storage/json_store.py
@@ -1,0 +1,84 @@
+"""Base class for a list of dataclass items persisted to a JSON file.
+
+`AlertStore`, `TaskStore`, and `AgentStore` all persisted a `list[...]` to a JSON
+file with byte-identical load/save/mtime-hot-reload boilerplate. This collapses
+that into one generic base; subclasses supply `_serialize`/`_deserialize` and their
+domain methods, and reuse `self._items` + `_save()`/`_maybe_reload()`/`_find()`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class JsonListStore(ABC, Generic[T]):
+    """A JSON-file-backed list of items with cross-process mtime hot-reload.
+
+    Subclasses set the class attribute ``_label`` (used in log messages) and
+    implement ``_serialize``/``_deserialize``. Reads that should observe external
+    writes call ``self._maybe_reload()`` first (as the domain query methods do).
+    """
+
+    _label: str = "items"
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._mtime: float = 0.0
+        self._items: list[T] = self._load()
+
+    @abstractmethod
+    def _serialize(self, item: T) -> dict[str, Any]:
+        """Convert one item to a JSON-serializable dict."""
+
+    @abstractmethod
+    def _deserialize(self, data: dict[str, Any]) -> T:
+        """Reconstruct one item from its stored dict."""
+
+    # -- persistence --------------------------------------------------------
+
+    def _maybe_reload(self) -> None:
+        """Re-read from disk if another process modified the file."""
+        if not self._path.exists():
+            return
+        try:
+            current_mtime = self._path.stat().st_mtime
+        except OSError:
+            return
+        if current_mtime != self._mtime:
+            self._items = self._load()
+
+    def _load(self) -> list[T]:
+        if not self._path.exists():
+            return []
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            self._mtime = self._path.stat().st_mtime
+            if isinstance(data, list):
+                return [self._deserialize(item) for item in data if isinstance(item, dict)]
+        except (json.JSONDecodeError, OSError, KeyError, ValueError):
+            logger.warning("Failed to load %s from %s", self._label, self._path)
+        return []
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = [self._serialize(item) for item in self._items]
+        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        self._mtime = self._path.stat().st_mtime
+
+    def _find(self, item_id: str) -> T | None:
+        """Return the item whose ``.id`` matches, or None."""
+        return next((i for i in self._items if getattr(i, "id", None) == item_id), None)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+
+__all__ = ["JsonListStore"]

--- a/qracer/task_executor.py
+++ b/qracer/task_executor.py
@@ -7,10 +7,10 @@ Can be driven by the REPL heartbeat or the ``qracer heartbeat`` CLI command.
 from __future__ import annotations
 
 import logging
-import time
 
 from qracer.data.registry import DataRegistry
 from qracer.llm.registry import LLMRegistry
+from qracer.monitors.base import PollingMonitor
 from qracer.tasks import (
     Task,
     TaskActionType,
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_CHECK_INTERVAL = 30  # seconds
 
 
-class TaskExecutor:
+class TaskExecutor(PollingMonitor):
     """Evaluates due tasks and dispatches their actions.
 
     Usage::
@@ -44,26 +44,19 @@ class TaskExecutor:
         engine: object | None = None,
         check_interval: float = DEFAULT_CHECK_INTERVAL,
     ) -> None:
+        super().__init__(check_interval)
         self._store = store
         self._data = data_registry
         self._llm = llm_registry
         self._engine = engine
-        self._check_interval = check_interval
-        self._last_check: float | None = None
 
     @property
     def store(self) -> TaskStore:
         return self._store
 
-    def should_check(self) -> bool:
-        """Return True if enough time has elapsed since the last check."""
-        if self._last_check is None:
-            return True
-        return (time.monotonic() - self._last_check) >= self._check_interval
-
     async def check(self) -> list[TaskResult]:
         """Execute all due tasks and return results."""
-        self._last_check = time.monotonic()
+        self._mark_checked()
         due = self._store.get_due()
         if not due:
             return []

--- a/qracer/tasks.py
+++ b/qracer/tasks.py
@@ -6,15 +6,15 @@ Supports one-time and recurring schedules without external dependencies.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from pathlib import Path
 from typing import Any
+
+from qracer.storage.json_store import JsonListStore
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +203,7 @@ class TaskResult:
 # ---------------------------------------------------------------------------
 
 
-class TaskStore:
+class TaskStore(JsonListStore[Task]):
     """File-backed storage for scheduled tasks.
 
     Usage::
@@ -213,14 +213,11 @@ class TaskStore:
         due = store.get_due()
     """
 
-    def __init__(self, path: Path) -> None:
-        self._path = path
-        self._mtime: float = 0.0
-        self._tasks: list[Task] = self._load()
+    _label = "tasks"
 
     @property
     def tasks(self) -> list[Task]:
-        return list(self._tasks)
+        return list(self._items)
 
     def create(
         self,
@@ -243,37 +240,26 @@ class TaskStore:
             created_at=now.isoformat(),
             next_run_at=next_run,
         )
-        self._tasks.append(task)
+        self._items.append(task)
         self._save()
         return task
-
-    def _maybe_reload(self) -> None:
-        """Re-read from disk if another process modified the file."""
-        if not self._path.exists():
-            return
-        try:
-            current_mtime = self._path.stat().st_mtime
-        except OSError:
-            return
-        if current_mtime != self._mtime:
-            self._tasks = self._load()
 
     def get_due(self, now: datetime | None = None) -> list[Task]:
         """Return tasks that are due for execution."""
         self._maybe_reload()
-        return [t for t in self._tasks if t.is_due(now)]
+        return [t for t in self._items if t.is_due(now)]
 
     def get_active(self) -> list[Task]:
         """Return tasks that are enabled and not completed."""
         self._maybe_reload()
-        return [t for t in self._tasks if t.enabled and t.status != TaskStatus.COMPLETED]
+        return [t for t in self._items if t.enabled and t.status != TaskStatus.COMPLETED]
 
     def get_all(self) -> list[Task]:
         self._maybe_reload()
-        return list(self._tasks)
+        return list(self._items)
 
     def mark_running(self, task_id: str) -> bool:
-        for t in self._tasks:
+        for t in self._items:
             if t.id == task_id:
                 t.status = TaskStatus.RUNNING
                 self._save()
@@ -281,7 +267,7 @@ class TaskStore:
         return False
 
     def mark_completed(self, task_id: str) -> bool:
-        for t in self._tasks:
+        for t in self._items:
             if t.id == task_id:
                 t.status = TaskStatus.COMPLETED
                 t.last_run_at = datetime.now(timezone.utc).isoformat()
@@ -292,7 +278,7 @@ class TaskStore:
         return False
 
     def mark_failed(self, task_id: str, error: str) -> bool:
-        for t in self._tasks:
+        for t in self._items:
             if t.id == task_id:
                 t.status = TaskStatus.FAILED
                 t.last_run_at = datetime.now(timezone.utc).isoformat()
@@ -304,7 +290,7 @@ class TaskStore:
 
     def advance_recurring(self, task_id: str) -> bool:
         """Recompute next_run for a recurring task and reset to PENDING."""
-        for t in self._tasks:
+        for t in self._items:
             if t.id == task_id and t.schedule_type == TaskScheduleType.RECURRING:
                 now = datetime.now(timezone.utc)
                 t.next_run_at = parse_schedule(t.schedule_spec, after=now).isoformat()
@@ -315,7 +301,7 @@ class TaskStore:
 
     def cancel(self, task_id: str) -> bool:
         """Disable a task. Returns True if found."""
-        for t in self._tasks:
+        for t in self._items:
             if t.id == task_id:
                 t.enabled = False
                 t.status = TaskStatus.COMPLETED
@@ -325,44 +311,21 @@ class TaskStore:
 
     def remove(self, task_id: str) -> bool:
         """Remove a task entirely. Returns True if found."""
-        for i, t in enumerate(self._tasks):
+        for i, t in enumerate(self._items):
             if t.id == task_id:
-                self._tasks.pop(i)
+                self._items.pop(i)
                 self._save()
                 return True
         return False
 
-    def __len__(self) -> int:
-        return len(self._tasks)
-
-    def _load(self) -> list[Task]:
-        if not self._path.exists():
-            return []
-        try:
-            data = json.loads(self._path.read_text(encoding="utf-8"))
-            self._mtime = self._path.stat().st_mtime
-            if isinstance(data, list):
-                return [self._deserialize(item) for item in data if isinstance(item, dict)]
-        except (json.JSONDecodeError, OSError, KeyError, ValueError):
-            logger.warning("Failed to load tasks from %s", self._path)
-        return []
-
-    def _save(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        data = [self._serialize(t) for t in self._tasks]
-        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        self._mtime = self._path.stat().st_mtime
-
-    @staticmethod
-    def _serialize(task: Task) -> dict[str, Any]:
+    def _serialize(self, task: Task) -> dict[str, Any]:
         d = asdict(task)
         d["action_type"] = task.action_type.value
         d["schedule_type"] = task.schedule_type.value
         d["status"] = task.status.value
         return d
 
-    @staticmethod
-    def _deserialize(data: dict[str, Any]) -> Task:
+    def _deserialize(self, data: dict[str, Any]) -> Task:
         return Task(
             id=data["id"],
             action_type=TaskActionType(data["action_type"]),

--- a/qracer/web/dashboard.py
+++ b/qracer/web/dashboard.py
@@ -9,14 +9,13 @@ the one editable section (reused from ``qracer.web.ui``).
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from qracer.config.loader import load_config
-from qracer.data.providers import PriceProvider
+from qracer.data.prices import fetch_prices
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -111,24 +110,6 @@ def _thesis_rows(theses: "list[PersistedThesis]") -> list[dict]:
         }
         for t in theses
     ]
-
-
-async def _fetch_prices(
-    data_registry: "DataRegistry | None", tickers: list[str]
-) -> dict[str, float]:
-    """Best-effort concurrent price fetch; skips tickers that fail."""
-    if data_registry is None or not tickers:
-        return {}
-
-    async def one(ticker: str) -> tuple[str, float | None]:
-        try:
-            price = await data_registry.async_get_with_fallback(PriceProvider, "get_price", ticker)
-            return ticker, float(price)
-        except Exception:  # noqa: BLE001 - best-effort per ticker
-            return ticker, None
-
-    results = await asyncio.gather(*(one(t) for t in tickers))
-    return {t: p for t, p in results if p is not None}
 
 
 def mount(
@@ -301,7 +282,7 @@ def mount(
         async def refresh_all() -> None:
             cfg = load_config()
             tickers = sorted({h.ticker for h in cfg.portfolio.holdings} | set(watchlist.tickers))
-            new_prices = await _fetch_prices(data_registry, tickers)
+            new_prices = await fetch_prices(data_registry, tickers)
             if new_prices:
                 prices.update(new_prices)
             for section in (

--- a/tests/data/test_prices.py
+++ b/tests/data/test_prices.py
@@ -1,0 +1,17 @@
+"""Tests for the shared best-effort price fetcher."""
+
+from __future__ import annotations
+
+from qracer.data.prices import fetch_prices
+
+
+class TestFetchPrices:
+    async def test_none_registry_returns_empty(self) -> None:
+        assert await fetch_prices(None, ["AAPL"]) == {}
+
+    async def test_no_tickers_returns_empty(self, data_registry) -> None:
+        assert await fetch_prices(data_registry, []) == {}
+
+    async def test_fetches_prices(self, data_registry) -> None:
+        prices = await fetch_prices(data_registry, ["AAPL", "MSFT"])
+        assert prices == {"AAPL": 150.0, "MSFT": 150.0}

--- a/tests/monitors/test_base.py
+++ b/tests/monitors/test_base.py
@@ -1,0 +1,25 @@
+"""Contract tests for the PollingMonitor throttle base."""
+
+from __future__ import annotations
+
+import time
+
+from qracer.monitors.base import PollingMonitor
+
+
+class TestPollingMonitor:
+    def test_first_check_is_always_due(self) -> None:
+        m = PollingMonitor(check_interval=1000)
+        assert m.should_check() is True
+
+    def test_throttles_after_mark(self) -> None:
+        m = PollingMonitor(check_interval=1000)
+        m._mark_checked()
+        assert m.should_check() is False  # just checked, not due again
+
+    def test_due_again_once_interval_elapsed(self) -> None:
+        m = PollingMonitor(check_interval=1000)
+        m._mark_checked()
+        # Simulate the interval having passed.
+        m._last_check = time.monotonic() - 1001
+        assert m.should_check() is True

--- a/tests/storage/test_json_store.py
+++ b/tests/storage/test_json_store.py
@@ -1,0 +1,59 @@
+"""Contract tests for the JsonListStore base (round-trip + hot-reload)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from qracer.storage.json_store import JsonListStore
+
+
+@dataclass
+class _Item:
+    id: str
+    value: int
+
+
+class _ItemStore(JsonListStore[_Item]):
+    _label = "items"
+
+    def _serialize(self, item: _Item) -> dict[str, Any]:
+        return {"id": item.id, "value": item.value}
+
+    def _deserialize(self, data: dict[str, Any]) -> _Item:
+        return _Item(id=data["id"], value=int(data["value"]))
+
+    def add(self, item: _Item) -> None:
+        self._items.append(item)
+        self._save()
+
+
+class TestJsonListStore:
+    def test_round_trip_persists_and_reloads(self, tmp_path: Path) -> None:
+        path = tmp_path / "items.json"
+        store = _ItemStore(path)
+        store.add(_Item("a", 1))
+        store.add(_Item("b", 2))
+        # A fresh store over the same file reads them back.
+        reloaded = _ItemStore(path)
+        assert len(reloaded) == 2
+        assert reloaded._find("b") == _Item("b", 2)
+
+    def test_hot_reload_on_external_write(self, tmp_path: Path) -> None:
+        path = tmp_path / "items.json"
+        store = _ItemStore(path)
+        store.add(_Item("a", 1))
+        # Another writer replaces the file's contents.
+        other = _ItemStore(path)
+        other.add(_Item("z", 9))
+        store._maybe_reload()
+        assert store._find("z") == _Item("z", 9)
+
+    def test_missing_file_is_empty(self, tmp_path: Path) -> None:
+        assert len(_ItemStore(tmp_path / "nope.json")) == 0
+
+    def test_corrupt_file_degrades_to_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "items.json"
+        path.write_text("not json", encoding="utf-8")
+        assert len(_ItemStore(path)) == 0

--- a/tests/test_agents_store.py
+++ b/tests/test_agents_store.py
@@ -211,7 +211,7 @@ class TestAgentStore:
 
         # Make cron due by rewriting next_run_at to the past directly.
         store.get(cron.id)
-        for a in store._agents:  # type: ignore[attr-defined]
+        for a in store._items:  # type: ignore[attr-defined]
             if a.id == cron.id:
                 a.next_run_at = (now - timedelta(minutes=1)).isoformat()
 

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -58,8 +58,8 @@ class TestTaskExecutor:
     async def test_check_executes_due_task(self, executor: TaskExecutor, store: TaskStore) -> None:
         store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
         # Force it to be due now
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
-        store._tasks[0].status = TaskStatus.PENDING
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].status = TaskStatus.PENDING
 
         results = await executor.check()
         assert len(results) == 1
@@ -68,14 +68,14 @@ class TestTaskExecutor:
 
     async def test_recurring_task_advances(self, executor: TaskExecutor, store: TaskStore) -> None:
         store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         await executor.check()
 
         # After execution, recurring task should be PENDING again with new next_run
-        assert store._tasks[0].status == TaskStatus.PENDING
-        assert store._tasks[0].run_count == 1
-        assert store._tasks[0].next_run_at != "2020-01-01T00:00:00+00:00"
+        assert store._items[0].status == TaskStatus.PENDING
+        assert store._items[0].run_count == 1
+        assert store._items[0].next_run_at != "2020-01-01T00:00:00+00:00"
 
     async def test_once_task_completed(self, executor: TaskExecutor, store: TaskStore) -> None:
         store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "2020-01-01T09:00:00")
@@ -83,7 +83,7 @@ class TestTaskExecutor:
 
         results = await executor.check()
         assert len(results) == 1
-        assert store._tasks[0].status == TaskStatus.COMPLETED
+        assert store._items[0].status == TaskStatus.COMPLETED
 
     async def test_failed_task(self, store: TaskStore) -> None:
         # Registry with no providers — will fail
@@ -91,7 +91,7 @@ class TestTaskExecutor:
         executor = TaskExecutor(store, empty_registry, LLMRegistry(), check_interval=0)
 
         store.create(TaskActionType.NEWS_SCAN, {"ticker": "AAPL"}, "every 1h")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         results = await executor.check()
         assert len(results) == 1
@@ -103,13 +103,13 @@ class TestTaskExecutor:
         executor = TaskExecutor(store, empty_registry, LLMRegistry(), check_interval=0)
 
         store.create(TaskActionType.NEWS_SCAN, {"ticker": "AAPL"}, "every 1h")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         await executor.check()
 
         # Even on failure, recurring task should advance
-        assert store._tasks[0].status == TaskStatus.PENDING
-        assert store._tasks[0].next_run_at != "2020-01-01T00:00:00+00:00"
+        assert store._items[0].status == TaskStatus.PENDING
+        assert store._items[0].next_run_at != "2020-01-01T00:00:00+00:00"
 
     async def test_custom_query_with_engine(self, store: TaskStore) -> None:
         mock_engine = MagicMock()
@@ -126,7 +126,7 @@ class TestTaskExecutor:
         )
 
         store.create(TaskActionType.CUSTOM_QUERY, {"query": "macro outlook"}, "every 1d")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         results = await executor.check()
         assert len(results) == 1
@@ -148,7 +148,7 @@ class TestTaskExecutor:
         )
 
         store.create(TaskActionType.ANALYZE, {"ticker": "TSLA"}, "every 2h")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         results = await executor.check()
         assert results[0].success is True
@@ -168,7 +168,7 @@ class TestTaskExecutor:
         )
 
         store.create(TaskActionType.PORTFOLIO_SNAPSHOT, {}, "every 1d")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         results = await executor.check()
         assert results[0].success is True
@@ -179,7 +179,7 @@ class TestTaskExecutor:
         executor = TaskExecutor(store, _make_registry(), LLMRegistry(), check_interval=0)
 
         store.create(TaskActionType.PORTFOLIO_SNAPSHOT, {}, "every 1d")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         results = await executor.check()
         assert results[0].success is True
@@ -189,7 +189,7 @@ class TestTaskExecutor:
         executor = TaskExecutor(store, _make_registry(), LLMRegistry(), check_interval=0)
 
         store.create(TaskActionType.CUSTOM_QUERY, {"query": "test"}, "every 1h")
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         results = await executor.check()
         assert results[0].success is True
@@ -203,7 +203,7 @@ class TestTaskExecutor:
             {"tickers": ["AAPL", "TSLA"]},
             "every 1d",
         )
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
 
         results = await executor.check()
         assert len(results) == 1

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -192,7 +192,7 @@ class TestTaskStore:
         assert len(store.get_due()) == 0
 
         # Manually set next_run to past
-        store._tasks[0].next_run_at = "2020-01-01T00:00:00+00:00"
+        store._items[0].next_run_at = "2020-01-01T00:00:00+00:00"
         assert len(store.get_due()) == 1
 
     def test_get_active(self, store: TaskStore) -> None:
@@ -200,34 +200,34 @@ class TestTaskStore:
         store.create(TaskActionType.NEWS_SCAN, {"ticker": "TSLA"}, "every 30m")
         assert len(store.get_active()) == 2
 
-        store.mark_completed(store._tasks[0].id)
+        store.mark_completed(store._items[0].id)
         assert len(store.get_active()) == 1
 
     def test_mark_running(self, store: TaskStore) -> None:
         task = store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
         assert store.mark_running(task.id)
-        assert store._tasks[0].status == TaskStatus.RUNNING
+        assert store._items[0].status == TaskStatus.RUNNING
 
     def test_mark_completed(self, store: TaskStore) -> None:
         task = store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
         assert store.mark_completed(task.id)
-        assert store._tasks[0].status == TaskStatus.COMPLETED
-        assert store._tasks[0].run_count == 1
-        assert store._tasks[0].last_run_at is not None
+        assert store._items[0].status == TaskStatus.COMPLETED
+        assert store._items[0].run_count == 1
+        assert store._items[0].last_run_at is not None
 
     def test_mark_failed(self, store: TaskStore) -> None:
         task = store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
         assert store.mark_failed(task.id, "connection error")
-        assert store._tasks[0].status == TaskStatus.FAILED
-        assert store._tasks[0].last_error == "connection error"
+        assert store._items[0].status == TaskStatus.FAILED
+        assert store._items[0].last_error == "connection error"
 
     def test_advance_recurring(self, store: TaskStore) -> None:
         task = store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
         old_next = task.next_run_at
         store.mark_completed(task.id)
         assert store.advance_recurring(task.id)
-        assert store._tasks[0].status == TaskStatus.PENDING
-        assert store._tasks[0].next_run_at != old_next
+        assert store._items[0].status == TaskStatus.PENDING
+        assert store._items[0].next_run_at != old_next
 
     def test_advance_recurring_fails_for_once(self, store: TaskStore) -> None:
         task = store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "2030-01-01T09:00:00")
@@ -236,8 +236,8 @@ class TestTaskStore:
     def test_cancel(self, store: TaskStore) -> None:
         task = store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
         assert store.cancel(task.id)
-        assert store._tasks[0].enabled is False
-        assert store._tasks[0].status == TaskStatus.COMPLETED
+        assert store._items[0].enabled is False
+        assert store._items[0].status == TaskStatus.COMPLETED
 
     def test_remove(self, store: TaskStore) -> None:
         task = store.create(TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h")
@@ -251,7 +251,7 @@ class TestTaskStore:
 
         store2 = TaskStore(path)
         assert len(store2) == 1
-        assert store2._tasks[0].action_type == TaskActionType.ANALYZE
+        assert store2._items[0].action_type == TaskActionType.ANALYZE
 
     def test_corrupt_file(self, tmp_path) -> None:
         path = tmp_path / "tasks.json"

--- a/tests/web/test_dashboard_builders.py
+++ b/tests/web/test_dashboard_builders.py
@@ -2,8 +2,8 @@
 
 The NiceGUI page in ``qracer.web.dashboard`` delegates all data shaping to small
 pure functions (``_portfolio_rows``, ``_watchlist_rows``, ``_alert_rows``,
-``_task_rows``, ``_thesis_rows``) plus ``_fetch_prices``. Those are tested here
-directly, without rendering any NiceGUI widgets.
+``_task_rows``, ``_thesis_rows``). Those are tested here directly, without
+rendering any NiceGUI widgets. (Price fetching moved to ``tests/data/test_prices.py``.)
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ from qracer.alerts import Alert, AlertCondition  # noqa: E402
 from qracer.config.models import Holding, PortfolioConfig  # noqa: E402
 from qracer.memory.fact_models import PersistedThesis, ThesisStatus  # noqa: E402
 from qracer.web import dashboard  # noqa: E402
-from tests.helpers import make_data_registry  # noqa: E402
 
 
 class TestCatalystLabel:
@@ -149,15 +148,3 @@ class TestThesisRows:
     def test_short_when_target_below_entry(self) -> None:
         rows = dashboard._thesis_rows([self._thesis(target=50.0, entry_high=100.0)])
         assert rows[0]["dir"] == "SHORT"
-
-
-class TestFetchPrices:
-    async def test_none_registry_returns_empty(self) -> None:
-        assert await dashboard._fetch_prices(None, ["AAPL"]) == {}
-
-    async def test_no_tickers_returns_empty(self) -> None:
-        assert await dashboard._fetch_prices(make_data_registry(), []) == {}
-
-    async def test_fetches_prices(self) -> None:
-        prices = await dashboard._fetch_prices(make_data_registry(), ["AAPL", "MSFT"])
-        assert prices == {"AAPL": 150.0, "MSFT": 150.0}


### PR DESCRIPTION
**Phase 1** of the phased code-quality refactor. Behavior-preserving extraction of three copy-pasted patterns; existing store + monitor tests are the regression net, with added direct contract tests for the new bases.

## What
- **`storage/json_store.py` — `JsonListStore[T]`**: the byte-identical `_load`/`_save`/`_maybe_reload`/`_find` + mtime bookkeeping that was duplicated across `AlertStore`, `TaskStore`, `AgentStore`. They now subclass it (public API unchanged); the private list attribute is unified as `_items`. ~90 lines of duplicated persistence removed.
- **`data/prices.py` — `fetch_prices(registry, tickers)`**: the identical best-effort concurrent price-fetch loop that was copy-pasted in `briefing.py` and `web/dashboard.py`.
- **`monitors/base.py` — `PollingMonitor`**: owns the `should_check()` monotonic throttle + `_mark_checked()`. `AlertMonitor`, `TaskExecutor`, `AgentMonitor`, `AutonomousMonitor` (market-hours guard via a `should_check` override), and `BriefingScheduler` inherit it — the throttle was copy-pasted 5×.

## Tests
Added `tests/storage/test_json_store.py` + `tests/monitors/test_base.py` (round-trip, hot-reload, corrupt-file, throttle contract); moved price-fetch tests to `tests/data/test_prices.py`; store tests updated for the `_items` rename.

**961 passed, pyright 0 errors, ruff/docs clean, coverage 81%.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)