### PR TITLE
refactor(phase4): shared dashboard presenters (web + Textual)

### DIFF
--- a/qracer/dashboard/panels.py
+++ b/qracer/dashboard/panels.py
@@ -12,6 +12,8 @@ from textual.containers import Vertical, VerticalScroll
 from textual.widgets import DataTable, Label, Static
 
 from qracer.config.loader import _user_dir, load_config
+from qracer.data.prices import fetch_prices as _fetch_prices
+from qracer.presenters import watchlist_rows
 from qracer.watchlist import Watchlist
 
 if TYPE_CHECKING:
@@ -33,28 +35,8 @@ def _format_change(change: float) -> str:
     return f"{sign}{change:.2f}%"
 
 
-async def _fetch_prices(data_registry: DataRegistry | None, tickers: list[str]) -> dict[str, float]:
-    """Fetch prices for *tickers* via ``PriceProvider`` fallback.
-
-    Returns an empty dict if no registry is provided.  Failures for
-    individual tickers are logged and skipped so that one bad symbol
-    does not blank the whole table.
-    """
-    if data_registry is None or not tickers:
-        return {}
-
-    from qracer.data.providers import PriceProvider
-
-    prices: dict[str, float] = {}
-    for ticker in tickers:
-        try:
-            price = await data_registry.async_get_with_fallback(PriceProvider, "get_price", ticker)
-        except Exception as exc:  # noqa: BLE001 — log and continue
-            logger.debug("Price fetch failed for %s: %s", ticker, exc)
-            continue
-        if isinstance(price, (int, float)):
-            prices[ticker] = float(price)
-    return prices
+# Price fetching is the shared best-effort helper (qracer.data.prices.fetch_prices),
+# imported above as _fetch_prices so the call sites below are unchanged.
 
 
 # ---------------------------------------------------------------------------
@@ -148,10 +130,8 @@ class OverviewPanel(VerticalScroll):
         if not wl.tickers:
             table.add_row("—", "—")
             return
-        for ticker in wl.tickers:
-            price = self._prices.get(ticker)
-            price_str = f"${price:,.2f}" if price is not None else "—"
-            table.add_row(ticker, price_str)
+        for row in watchlist_rows(list(wl.tickers), self._prices):
+            table.add_row(row["ticker"], row["price"])
 
     async def refresh_data(self) -> None:
         """Fetch live prices and rebuild the tables."""
@@ -288,10 +268,8 @@ class WatchlistPanel(VerticalScroll):
             hint.update("Watchlist is empty. Use 'qracer repl' → 'watch TICKER' to add.")
             return
         hint.update("")
-        for ticker in wl.tickers:
-            price = self._prices.get(ticker)
-            price_str = f"${price:,.2f}" if price is not None else "—"
-            table.add_row(ticker, price_str)
+        for row in watchlist_rows(list(wl.tickers), self._prices):
+            table.add_row(row["ticker"], row["price"])
 
     async def refresh_data(self) -> None:
         """Fetch live prices for watchlist tickers and rebuild the table."""

--- a/qracer/presenters.py
+++ b/qracer/presenters.py
@@ -1,0 +1,101 @@
+"""Pure view-model builders shared by the web (NiceGUI) and TUI (Textual) dashboards.
+
+Both dashboards showed the same data — portfolio holdings with P&L, watchlist prices,
+alerts, tasks, open theses — and each formatted it independently. These functions are
+the single source of that formatting: they take domain objects + a price map and return
+plain dicts of display strings, with no UI dependency, so either front-end can render them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qracer.alerts import Alert
+    from qracer.config.models import PortfolioConfig
+    from qracer.memory.fact_store import PersistedThesis
+    from qracer.tasks import Task
+
+
+def catalyst_label(catalyst: str | None, catalyst_date: str | None) -> str:
+    when = f" ({catalyst_date})" if catalyst_date else ""
+    return f"{catalyst or '—'}{when}"
+
+
+def portfolio_rows(
+    portfolio: "PortfolioConfig", prices: dict[str, float]
+) -> tuple[list[dict], float]:
+    """Return (holding rows, total value). Missing prices fall back to avg cost."""
+    holdings = portfolio.holdings
+    if not holdings:
+        return [], 0.0
+    from qracer.risk.calculator import RiskCalculator
+
+    price_map = {h.ticker: prices.get(h.ticker, h.avg_cost) for h in holdings}
+    snap = RiskCalculator(portfolio).build_snapshot(price_map)
+    rows: list[dict] = []
+    for h in snap.holdings:
+        pnl_sign = "+" if h.unrealized_pnl >= 0 else "-"
+        rows.append(
+            {
+                "ticker": h.ticker,
+                "shares": f"{h.shares:g}",
+                "price": f"${h.current_price:,.2f}",
+                "value": f"${h.market_value:,.0f}",
+                "weight": f"{h.weight_pct:.1f}%",
+                "pnl": f"{pnl_sign}{abs(h.unrealized_pnl_pct):.1f}%",
+            }
+        )
+    return rows, snap.total_value
+
+
+def watchlist_rows(tickers: list[str], prices: dict[str, float]) -> list[dict]:
+    return [{"ticker": t, "price": f"${prices[t]:,.2f}" if t in prices else "—"} for t in tickers]
+
+
+def alert_rows(alerts: "list[Alert]") -> list[dict]:
+    return [
+        {
+            "ticker": a.ticker,
+            "condition": a.condition.value,
+            "threshold": f"{a.threshold:g}",
+            "status": "active" if a.active else "triggered",
+        }
+        for a in alerts
+    ]
+
+
+def task_rows(tasks: "list[Task]") -> list[dict]:
+    return [
+        {
+            "action": t.describe(),
+            "schedule": t.schedule_spec,
+            "status": t.status.value,
+            "next": t.next_run_at or "—",
+        }
+        for t in tasks
+    ]
+
+
+def thesis_rows(theses: "list[PersistedThesis]") -> list[dict]:
+    return [
+        {
+            "ticker": t.ticker,
+            "dir": "LONG" if t.target_price >= t.entry_zone_high else "SHORT",
+            "conv": f"{t.conviction}/10",
+            "target": f"${t.target_price:,.2f}",
+            "stop": f"${t.stop_loss:,.2f}",
+            "catalyst": catalyst_label(t.catalyst, t.catalyst_date),
+        }
+        for t in theses
+    ]
+
+
+__all__ = [
+    "alert_rows",
+    "catalyst_label",
+    "portfolio_rows",
+    "task_rows",
+    "thesis_rows",
+    "watchlist_rows",
+]

--- a/qracer/web/dashboard.py
+++ b/qracer/web/dashboard.py
@@ -16,16 +16,28 @@ from typing import TYPE_CHECKING, cast
 
 from qracer.config.loader import load_config
 from qracer.data.prices import fetch_prices
+from qracer.presenters import (
+    alert_rows as _alert_rows,
+)
+from qracer.presenters import (
+    portfolio_rows as _portfolio_rows,
+)
+from qracer.presenters import (
+    task_rows as _task_rows,
+)
+from qracer.presenters import (
+    thesis_rows as _thesis_rows,
+)
+from qracer.presenters import (
+    watchlist_rows as _watchlist_rows,
+)
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-    from qracer.alerts import Alert
-    from qracer.config.models import PortfolioConfig
     from qracer.data.registry import DataRegistry
     from qracer.llm.registry import LLMRegistry
-    from qracer.memory.fact_store import FactStore, PersistedThesis
-    from qracer.tasks import Task
+    from qracer.memory.fact_store import FactStore
 
 logger = logging.getLogger(__name__)
 
@@ -33,83 +45,6 @@ REFRESH_SECONDS = 5.0
 _BRIEFING_TTL = 900.0  # reuse a composed briefing for 15 min (single-user tool)
 # Module-level cache so the LLM briefing isn't recomposed on every page load / viewer.
 _briefing_cache: dict[str, object] = {"text": None, "at": 0.0}
-
-
-def _catalyst_label(catalyst: str | None, catalyst_date: str | None) -> str:
-    when = f" ({catalyst_date})" if catalyst_date else ""
-    return f"{catalyst or '—'}{when}"
-
-
-# -- pure row builders (no NiceGUI): rendered by the page, unit-tested directly --
-
-
-def _portfolio_rows(
-    portfolio: "PortfolioConfig", prices: dict[str, float]
-) -> tuple[list[dict], float]:
-    """Return (holding rows, total value). Missing prices fall back to avg cost."""
-    holdings = portfolio.holdings
-    if not holdings:
-        return [], 0.0
-    from qracer.risk.calculator import RiskCalculator
-
-    price_map = {h.ticker: prices.get(h.ticker, h.avg_cost) for h in holdings}
-    snap = RiskCalculator(portfolio).build_snapshot(price_map)
-    rows: list[dict] = []
-    for h in snap.holdings:
-        pnl_sign = "+" if h.unrealized_pnl >= 0 else "-"
-        rows.append(
-            {
-                "ticker": h.ticker,
-                "shares": f"{h.shares:g}",
-                "price": f"${h.current_price:,.2f}",
-                "value": f"${h.market_value:,.0f}",
-                "weight": f"{h.weight_pct:.1f}%",
-                "pnl": f"{pnl_sign}{abs(h.unrealized_pnl_pct):.1f}%",
-            }
-        )
-    return rows, snap.total_value
-
-
-def _watchlist_rows(tickers: list[str], prices: dict[str, float]) -> list[dict]:
-    return [{"ticker": t, "price": f"${prices[t]:,.2f}" if t in prices else "—"} for t in tickers]
-
-
-def _alert_rows(alerts: "list[Alert]") -> list[dict]:
-    return [
-        {
-            "ticker": a.ticker,
-            "condition": a.condition.value,
-            "threshold": f"{a.threshold:g}",
-            "status": "active" if a.active else "triggered",
-        }
-        for a in alerts
-    ]
-
-
-def _task_rows(tasks: "list[Task]") -> list[dict]:
-    return [
-        {
-            "action": t.describe(),
-            "schedule": t.schedule_spec,
-            "status": t.status.value,
-            "next": t.next_run_at or "—",
-        }
-        for t in tasks
-    ]
-
-
-def _thesis_rows(theses: "list[PersistedThesis]") -> list[dict]:
-    return [
-        {
-            "ticker": t.ticker,
-            "dir": "LONG" if t.target_price >= t.entry_zone_high else "SHORT",
-            "conv": f"{t.conviction}/10",
-            "target": f"${t.target_price:,.2f}",
-            "stop": f"${t.stop_loss:,.2f}",
-            "catalyst": _catalyst_label(t.catalyst, t.catalyst_date),
-        }
-        for t in theses
-    ]
 
 
 def mount(

--- a/tests/test_presenters.py
+++ b/tests/test_presenters.py
@@ -1,10 +1,4 @@
-"""Unit tests for the dashboard's pure row-builders.
-
-The NiceGUI page in ``qracer.web.dashboard`` delegates all data shaping to small
-pure functions (``_portfolio_rows``, ``_watchlist_rows``, ``_alert_rows``,
-``_task_rows``, ``_thesis_rows``). Those are tested here directly, without
-rendering any NiceGUI widgets. (Price fetching moved to ``tests/data/test_prices.py``.)
-"""
+"""Unit tests for the shared dashboard presenters (pure view-model builders)."""
 
 from __future__ import annotations
 
@@ -13,34 +7,32 @@ from types import SimpleNamespace
 
 import pytest
 
-pytest.importorskip("nicegui")
-
-from qracer.alerts import Alert, AlertCondition  # noqa: E402
-from qracer.config.models import Holding, PortfolioConfig  # noqa: E402
-from qracer.memory.fact_models import PersistedThesis, ThesisStatus  # noqa: E402
-from qracer.web import dashboard  # noqa: E402
+from qracer import presenters
+from qracer.alerts import Alert, AlertCondition
+from qracer.config.models import Holding, PortfolioConfig
+from qracer.memory.fact_models import PersistedThesis, ThesisStatus
 
 
 class TestCatalystLabel:
     def test_with_date(self) -> None:
-        assert dashboard._catalyst_label("Earnings", "2026-05-01") == "Earnings (2026-05-01)"
+        assert presenters.catalyst_label("Earnings", "2026-05-01") == "Earnings (2026-05-01)"
 
     def test_without_date(self) -> None:
-        assert dashboard._catalyst_label("Earnings", None) == "Earnings"
+        assert presenters.catalyst_label("Earnings", None) == "Earnings"
 
     def test_no_catalyst(self) -> None:
-        assert dashboard._catalyst_label(None, None) == "—"
+        assert presenters.catalyst_label(None, None) == "—"
 
 
 class TestPortfolioRows:
     def test_empty_portfolio(self) -> None:
-        rows, total = dashboard._portfolio_rows(PortfolioConfig(holdings=[]), {})
+        rows, total = presenters.portfolio_rows(PortfolioConfig(holdings=[]), {})
         assert rows == []
         assert total == 0.0
 
     def test_uses_live_price_and_formats(self) -> None:
         portfolio = PortfolioConfig(holdings=[Holding(ticker="AAPL", shares=10, avg_cost=100.0)])
-        rows, total = dashboard._portfolio_rows(portfolio, {"AAPL": 150.0})
+        rows, total = presenters.portfolio_rows(portfolio, {"AAPL": 150.0})
         assert len(rows) == 1
         assert rows[0]["ticker"] == "AAPL"
         assert rows[0]["price"] == "$150.00"
@@ -49,14 +41,14 @@ class TestPortfolioRows:
 
     def test_falls_back_to_avg_cost_when_price_missing(self) -> None:
         portfolio = PortfolioConfig(holdings=[Holding(ticker="AAPL", shares=10, avg_cost=100.0)])
-        rows, _ = dashboard._portfolio_rows(portfolio, {})  # no live price
+        rows, _ = presenters.portfolio_rows(portfolio, {})  # no live price
         assert rows[0]["price"] == "$100.00"
         assert rows[0]["pnl"] == "+0.0%"
 
 
 class TestWatchlistRows:
     def test_priced_and_unpriced(self) -> None:
-        rows = dashboard._watchlist_rows(["AAPL", "MSFT"], {"AAPL": 150.0})
+        rows = presenters.watchlist_rows(["AAPL", "MSFT"], {"AAPL": 150.0})
         assert rows == [
             {"ticker": "AAPL", "price": "$150.00"},
             {"ticker": "MSFT", "price": "—"},
@@ -83,7 +75,7 @@ class TestAlertRows:
                 active=False,
             ),
         ]
-        rows = dashboard._alert_rows(alerts)
+        rows = presenters.alert_rows(alerts)
         assert rows[0]["status"] == "active"
         assert rows[0]["threshold"] == "200"
         assert rows[1]["status"] == "triggered"
@@ -97,7 +89,7 @@ class TestTaskRows:
             status=SimpleNamespace(value="active"),
             next_run_at="2026-05-01T09:00",
         )
-        rows = dashboard._task_rows([task])  # type: ignore[list-item]
+        rows = presenters.task_rows([task])  # type: ignore[list-item]
         assert rows == [
             {
                 "action": "news AAPL",
@@ -114,7 +106,7 @@ class TestTaskRows:
             status=SimpleNamespace(value="paused"),
             next_run_at=None,
         )
-        rows = dashboard._task_rows([task])  # type: ignore[list-item]
+        rows = presenters.task_rows([task])  # type: ignore[list-item]
         assert rows[0]["next"] == "—"
 
 
@@ -140,11 +132,11 @@ class TestThesisRows:
         )
 
     def test_long_when_target_above_entry(self) -> None:
-        rows = dashboard._thesis_rows([self._thesis(target=200.0, entry_high=100.0)])
+        rows = presenters.thesis_rows([self._thesis(target=200.0, entry_high=100.0)])
         assert rows[0]["dir"] == "LONG"
         assert rows[0]["conv"] == "7/10"
         assert rows[0]["catalyst"] == "Earnings (2026-05-01)"
 
     def test_short_when_target_below_entry(self) -> None:
-        rows = dashboard._thesis_rows([self._thesis(target=50.0, entry_high=100.0)])
+        rows = presenters.thesis_rows([self._thesis(target=50.0, entry_high=100.0)])
         assert rows[0]["dir"] == "SHORT"


### PR DESCRIPTION
**Phase 4.** The NiceGUI web dashboard and the Textual TUI each formatted the same data (holdings/watchlist/alerts/tasks/theses) independently. Introduces a neutral, UI-free view-model module both consume.

## What
- **`qracer/presenters.py` (new)**: the pure row-builders (`portfolio_rows`, `watchlist_rows`, `alert_rows`, `task_rows`, `thesis_rows`, `catalyst_label`) — moved out of `web/dashboard.py`, now UI-agnostic and **100% covered**.
- `web/dashboard.py` imports them (thin `_x = presenters.x` aliases keep the render closures + call sites unchanged).
- `dashboard/panels.py` (Textual): dropped its own **sequential** `_fetch_prices` for the shared `qracer.data.prices.fetch_prices`, and both watchlist populators now use `presenters.watchlist_rows`. The richer portfolio/alerts/tasks TUI panels keep their own column layout (extra fields like Avg Cost), but the shared formatting home now exists.
- Builder tests moved to `tests/test_presenters.py` (targeting the real module).

Behavior-preserving: **961 passed, pyright 0 errors, ruff/docs clean, coverage 81%.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)