### PR TITLE
refactor(phase5): generic KeyedRegistry base + provider-discovery helper

### DIFF
--- a/qracer/data/registry.py
+++ b/qracer/data/registry.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from qracer.registry_base import KeyedRegistry
+
 # Provider protocol classes are used as capability keys (e.g. PriceProvider, NewsProvider).
 # pyright doesn't support type[Protocol], so we use type[Any] as the capability type.
 ProviderType = type[Any]
@@ -16,144 +18,73 @@ ProviderType = type[Any]
 logger = logging.getLogger(__name__)
 
 
-class DataRegistry:
+class DataRegistry(KeyedRegistry[ProviderType, Any]):
     """Routes data requests by capability with ordered fallback."""
 
-    def __init__(self) -> None:
-        # capability -> list of (name, adapter) in priority order
-        self._adapters: dict[ProviderType, list[tuple[str, Any]]] = {}
+    _item_noun = "adapter"
+    _key_noun = "capability"
+
+    def _key_label(self, key: ProviderType) -> str:
+        return key.__name__
 
     def register(self, name: str, adapter: Any, capabilities: list[ProviderType]) -> None:
-        """Register an adapter with its capabilities.
-
-        Adapters registered first for a given capability have higher priority.
-        """
-        for cap in capabilities:
-            if cap not in self._adapters:
-                self._adapters[cap] = []
-            self._adapters[cap].append((name, adapter))
+        """Register an adapter with its capabilities (earlier = higher priority)."""
+        self._register(name, adapter, capabilities)
 
     def get(self, capability: ProviderType, name: str | None = None) -> Any:
-        """Get the highest-priority adapter for a capability.
+        """Get the highest-priority adapter for a capability (or a named one).
 
-        This is a simple lookup — it returns the adapter instance without
-        invoking any methods.  For call-level fallback (try the primary
-        adapter, fall through to the next on failure) use
-        :meth:`get_with_fallback` or :meth:`async_get_with_fallback`.
-
-        Args:
-            capability: The provider protocol to look up.
-            name: If provided, return the adapter with this name specifically.
-
-        Returns:
-            The adapter instance.
+        A simple lookup — no methods invoked. For call-level fallback use
+        :meth:`get_with_fallback` / :meth:`async_get_with_fallback`.
 
         Raises:
             KeyError: If no adapter is registered for the capability (or name).
         """
-        adapters = self._adapters.get(capability)
-        if not adapters:
-            raise KeyError(f"No adapter registered for capability {capability.__name__}")
-
-        if name is not None:
-            for adapter_name, adapter in adapters:
-                if adapter_name == name:
-                    return adapter
-            raise KeyError(f"No adapter named '{name}' for capability {capability.__name__}")
-
-        return adapters[0][1]
-
-    def get_with_fallback(
-        self,
-        capability: ProviderType,
-        method: str,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
-        """Call *method* on each adapter for *capability* until one succeeds.
-
-        Args:
-            capability: The provider protocol to look up.
-            method: The method name to call on the adapter.
-            *args: Positional arguments forwarded to the method.
-            **kwargs: Keyword arguments forwarded to the method.
-
-        Returns:
-            The return value from the first successful adapter call.
-
-        Raises:
-            KeyError: If no adapter is registered for the capability.
-            Exception: The last exception if all adapters fail.
-        """
-        adapters = self._adapters.get(capability)
-        if not adapters:
-            raise KeyError(f"No adapter registered for capability {capability.__name__}")
-
-        last_exc: Exception | None = None
-        for adapter_name, adapter in adapters:
-            try:
-                fn = getattr(adapter, method)
-                return fn(*args, **kwargs)
-            except Exception as exc:
-                last_exc = exc
-                logger.warning(
-                    "Adapter '%s'.%s failed, trying next: %s",
-                    adapter_name,
-                    method,
-                    exc,
-                )
-
-        raise last_exc  # type: ignore[misc]
-
-    async def async_get_with_fallback(
-        self,
-        capability: ProviderType,
-        method: str,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
-        """Call an async *method* on each adapter for *capability* until one succeeds.
-
-        Same as :meth:`get_with_fallback` but awaits the adapter method,
-        making it suitable for the async pipeline tools.
-
-        Args:
-            capability: The provider protocol to look up.
-            method: The async method name to call on the adapter.
-            *args: Positional arguments forwarded to the method.
-            **kwargs: Keyword arguments forwarded to the method.
-
-        Returns:
-            The return value from the first successful adapter call.
-
-        Raises:
-            KeyError: If no adapter is registered for the capability.
-            Exception: The last exception if all adapters fail.
-        """
-        adapters = self._adapters.get(capability)
-        if not adapters:
-            raise KeyError(f"No adapter registered for capability {capability.__name__}")
-
-        last_exc: Exception | None = None
-        for adapter_name, adapter in adapters:
-            try:
-                fn = getattr(adapter, method)
-                return await fn(*args, **kwargs)
-            except Exception as exc:
-                last_exc = exc
-                logger.warning(
-                    "Adapter '%s'.%s failed, trying next: %s",
-                    adapter_name,
-                    method,
-                    exc,
-                )
-
-        raise last_exc  # type: ignore[misc]
+        return self._get(capability, name)
 
     def get_all(self, capability: ProviderType) -> list[tuple[str, Any]]:
         """Get all adapters for a capability in priority order."""
-        return list(self._adapters.get(capability, []))
+        return self._get_all(capability)
 
     def capabilities(self) -> list[ProviderType]:
         """List all registered capabilities."""
-        return list(self._adapters.keys())
+        return self._keys()
+
+    def _require(self, capability: ProviderType) -> list[tuple[str, Any]]:
+        """Adapters for *capability*, or raise the standard 'not registered' KeyError."""
+        adapters = self._get_all(capability)
+        if not adapters:
+            noun, key_noun, label = self._item_noun, self._key_noun, self._key_label(capability)
+            raise KeyError(f"No {noun} registered for {key_noun} {label}")
+        return adapters
+
+    def get_with_fallback(
+        self, capability: ProviderType, method: str, *args: Any, **kwargs: Any
+    ) -> Any:
+        """Call *method* on each adapter for *capability* until one succeeds.
+
+        Raises:
+            KeyError: If no adapter is registered for the capability.
+            Exception: The last exception if all adapters fail.
+        """
+        last_exc: Exception | None = None
+        for adapter_name, adapter in self._require(capability):
+            try:
+                return getattr(adapter, method)(*args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                logger.warning("Adapter '%s'.%s failed, trying next: %s", adapter_name, method, exc)
+        raise last_exc  # type: ignore[misc]
+
+    async def async_get_with_fallback(
+        self, capability: ProviderType, method: str, *args: Any, **kwargs: Any
+    ) -> Any:
+        """Async twin of :meth:`get_with_fallback` — awaits each adapter method."""
+        last_exc: Exception | None = None
+        for adapter_name, adapter in self._require(capability):
+            try:
+                return await getattr(adapter, method)(*args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                logger.warning("Adapter '%s'.%s failed, trying next: %s", adapter_name, method, exc)
+        raise last_exc  # type: ignore[misc]

--- a/qracer/llm/registry.py
+++ b/qracer/llm/registry.py
@@ -7,54 +7,30 @@ Per-role assignment is overridable via config.
 from __future__ import annotations
 
 from qracer.llm.providers import LLMProvider, Role
+from qracer.registry_base import KeyedRegistry
 
 
-class LLMRegistry:
+class LLMRegistry(KeyedRegistry[Role, LLMProvider]):
     """Routes LLM requests by role with ordered fallback."""
 
-    def __init__(self) -> None:
-        # role -> list of (name, provider) in priority order
-        self._providers: dict[Role, list[tuple[str, LLMProvider]]] = {}
+    _item_noun = "provider"
+    _key_noun = "role"
+
+    def _key_label(self, key: Role) -> str:
+        return key.value
 
     def register(self, name: str, provider: LLMProvider, roles: list[Role]) -> None:
-        """Register a provider for the given roles.
-
-        Providers registered first for a given role have higher priority.
-        """
-        for role in roles:
-            if role not in self._providers:
-                self._providers[role] = []
-            self._providers[role].append((name, provider))
+        """Register a provider for the given roles (earlier = higher priority)."""
+        self._register(name, provider, roles)
 
     def get(self, role: Role, name: str | None = None) -> LLMProvider:
-        """Get a provider by role, optionally by explicit name.
-
-        Args:
-            role: The role to look up.
-            name: If provided, return the provider with this name specifically.
-
-        Returns:
-            The provider instance.
-
-        Raises:
-            KeyError: If no provider is registered for the role (or name).
-        """
-        providers = self._providers.get(role)
-        if not providers:
-            raise KeyError(f"No provider registered for role {role.value}")
-
-        if name is not None:
-            for provider_name, provider in providers:
-                if provider_name == name:
-                    return provider
-            raise KeyError(f"No provider named '{name}' for role {role.value}")
-
-        return providers[0][1]
+        """Get a provider by role, optionally by explicit name. Raises KeyError."""
+        return self._get(role, name)
 
     def get_all(self, role: Role) -> list[tuple[str, LLMProvider]]:
         """Get all providers for a role in priority order."""
-        return list(self._providers.get(role, []))
+        return self._get_all(role)
 
     def roles(self) -> list[Role]:
         """List all registered roles."""
-        return list(self._providers.keys())
+        return self._keys()

--- a/qracer/provider_catalog.py
+++ b/qracer/provider_catalog.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import logging
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -98,84 +99,72 @@ _DATA_CAPABILITY_PROTOCOLS: list[tuple[str, str]] = [
 ]
 
 
-def discover_data_providers() -> dict[str, tuple[str, list[str]]]:
-    """Discover data providers from entry points and merge with built-ins.
+def _discover(
+    group: str,
+    builtins: dict[str, tuple[str, list[str]]],
+    kind: str,
+    extract_meta: Callable[[type, str], list[str]],
+) -> dict[str, tuple[str, list[str]]]:
+    """Merge *builtins* with providers found on the *group* entry-point group.
 
-    Scans the ``qracer.data_providers`` entry-point group.  Each entry point
-    should reference an adapter class.  Capabilities are detected by checking
-    the adapter class against the runtime-checkable data-provider protocols.
-
-    Returns a merged catalog in the same format as
-    :data:`BUILTIN_DATA_PROVIDERS`.
+    ``extract_meta(adapter_cls, ep_name)`` returns the metadata list (capability
+    paths or role values); an empty list means "skip" and the extractor is
+    responsible for logging why.
     """
-    merged = dict(BUILTIN_DATA_PROVIDERS)
-
-    eps = importlib.metadata.entry_points(group="qracer.data_providers")
-    for ep in eps:
+    merged = dict(builtins)
+    for ep in importlib.metadata.entry_points(group=group):
         try:
             adapter_cls = ep.load()
         except Exception as exc:
-            logger.warning("Failed to load data-provider entry point '%s': %s", ep.name, exc)
+            logger.warning("Failed to load %s-provider entry point '%s': %s", kind, ep.name, exc)
             continue
-
-        # Detect which capability protocols this adapter satisfies.
-        caps: list[str] = []
-        for mod_path, cls_name in _DATA_CAPABILITY_PROTOCOLS:
-            try:
-                mod = importlib.import_module(mod_path)
-                protocol_cls = getattr(mod, cls_name)
-                if isinstance(adapter_cls(), protocol_cls):
-                    caps.append(f"{mod_path}.{cls_name}")
-            except Exception:
-                continue
-
-        if not caps:
-            logger.warning(
-                "Data-provider entry point '%s' does not satisfy any known "
-                "capability protocol — skipped",
-                ep.name,
-            )
-            continue
-
+        meta = extract_meta(adapter_cls, ep.name)
+        if not meta:
+            continue  # extract_meta logged the skip reason
         adapter_import_path = f"{adapter_cls.__module__}.{adapter_cls.__qualname__}"
-        merged[ep.name] = (adapter_import_path, caps)
-        logger.info("Discovered external data provider '%s' with capabilities %s", ep.name, caps)
-
+        merged[ep.name] = (adapter_import_path, meta)
+        logger.info("Discovered external %s provider '%s': %s", kind, ep.name, meta)
     return merged
+
+
+def _data_capabilities(adapter_cls: type, ep_name: str) -> list[str]:
+    """Capability protocol paths an adapter class satisfies (empty → skip)."""
+    caps: list[str] = []
+    for mod_path, cls_name in _DATA_CAPABILITY_PROTOCOLS:
+        try:
+            protocol_cls = getattr(importlib.import_module(mod_path), cls_name)
+            if isinstance(adapter_cls(), protocol_cls):
+                caps.append(f"{mod_path}.{cls_name}")
+        except Exception:
+            continue
+    if not caps:
+        logger.warning(
+            "Data-provider entry point '%s' does not satisfy any known "
+            "capability protocol — skipped",
+            ep_name,
+        )
+    return caps
+
+
+def _llm_roles(adapter_cls: type, ep_name: str) -> list[str]:
+    """Role values from an adapter class's ``roles`` attribute (empty → skip)."""
+    raw_roles = getattr(adapter_cls, "roles", None)
+    if not raw_roles:
+        logger.warning(
+            "LLM-provider entry point '%s' has no 'roles' class attribute — skipped", ep_name
+        )
+        return []
+    return [r.value if hasattr(r, "value") else str(r) for r in raw_roles]
+
+
+def discover_data_providers() -> dict[str, tuple[str, list[str]]]:
+    """Discover data providers from the ``qracer.data_providers`` entry-point group,
+    merged with the built-ins. Capabilities are detected against the runtime-checkable
+    data-provider protocols."""
+    return _discover("qracer.data_providers", BUILTIN_DATA_PROVIDERS, "data", _data_capabilities)
 
 
 def discover_llm_providers() -> dict[str, tuple[str, list[str]]]:
-    """Discover LLM providers from entry points and merge with built-ins.
-
-    Scans the ``qracer.llm_providers`` entry-point group.  Each entry point
-    should reference an adapter class that has a ``roles`` class attribute
-    (a list of :class:`~qracer.llm.providers.Role` values).
-
-    Returns a merged catalog in the same format as
-    :data:`BUILTIN_LLM_PROVIDERS`.
-    """
-    merged = dict(BUILTIN_LLM_PROVIDERS)
-
-    eps = importlib.metadata.entry_points(group="qracer.llm_providers")
-    for ep in eps:
-        try:
-            adapter_cls = ep.load()
-        except Exception as exc:
-            logger.warning("Failed to load LLM-provider entry point '%s': %s", ep.name, exc)
-            continue
-
-        # Extract roles from the adapter class attribute.
-        raw_roles = getattr(adapter_cls, "roles", None)
-        if not raw_roles:
-            logger.warning(
-                "LLM-provider entry point '%s' has no 'roles' class attribute — skipped",
-                ep.name,
-            )
-            continue
-
-        role_values = [r.value if hasattr(r, "value") else str(r) for r in raw_roles]
-        adapter_import_path = f"{adapter_cls.__module__}.{adapter_cls.__qualname__}"
-        merged[ep.name] = (adapter_import_path, role_values)
-        logger.info("Discovered external LLM provider '%s' with roles %s", ep.name, role_values)
-
-    return merged
+    """Discover LLM providers from the ``qracer.llm_providers`` entry-point group,
+    merged with the built-ins. Roles come from each adapter class's ``roles`` attribute."""
+    return _discover("qracer.llm_providers", BUILTIN_LLM_PROVIDERS, "LLM", _llm_roles)

--- a/qracer/registry_base.py
+++ b/qracer/registry_base.py
@@ -1,0 +1,61 @@
+"""Generic keyed registry shared by DataRegistry (capability→adapter) and
+LLMRegistry (role→provider).
+
+Both mapped a key to a priority-ordered ``list[(name, obj)]`` with identical
+register / get / get-all / list-keys logic and only different error wording. This
+base holds that logic; subclasses set the nouns and how a key is rendered in errors.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class KeyedRegistry(Generic[K, V]):
+    """A key → priority-ordered ``[(name, value), ...]`` registry with named lookup."""
+
+    # Subclasses override these to preserve their exact error messages.
+    _item_noun: str = "item"
+    _key_noun: str = "key"
+
+    def __init__(self) -> None:
+        self._entries: dict[K, list[tuple[str, V]]] = {}
+
+    def _key_label(self, key: K) -> str:
+        """How a key appears in error messages (e.g. ``cap.__name__`` / ``role.value``)."""
+        return str(key)
+
+    def _register(self, name: str, value: V, keys: list[K]) -> None:
+        """Register *value* under each key; earlier registrations rank higher."""
+        for key in keys:
+            self._entries.setdefault(key, []).append((name, value))
+
+    def _get(self, key: K, name: str | None = None) -> V:
+        """Highest-priority value for *key*, or the named one. Raises KeyError."""
+        entries = self._entries.get(key)
+        if not entries:
+            raise KeyError(
+                f"No {self._item_noun} registered for {self._key_noun} {self._key_label(key)}"
+            )
+        if name is not None:
+            for entry_name, value in entries:
+                if entry_name == name:
+                    return value
+            raise KeyError(
+                f"No {self._item_noun} named '{name}' for {self._key_noun} {self._key_label(key)}"
+            )
+        return entries[0][1]
+
+    def _get_all(self, key: K) -> list[tuple[str, V]]:
+        """All (name, value) for *key* in priority order."""
+        return list(self._entries.get(key, []))
+
+    def _keys(self) -> list[K]:
+        """All registered keys."""
+        return list(self._entries.keys())
+
+
+__all__ = ["KeyedRegistry"]


### PR DESCRIPTION
**Phase 5.** `DataRegistry` and `LLMRegistry` duplicated their register/get/get_all/list-keys logic (a key → priority-ordered `[(name, obj)]` map), and the two provider-discovery functions shared ~half their body. Both deduplicated, behavior-preserving (exact error messages kept).

- **`qracer/registry_base.py` (new)**: `KeyedRegistry[K, V]` holding the shared map + register/get(+named)/get_all/keys. Subclasses set `_item_noun`/`_key_noun` and `_key_label` so the `KeyError` text is byte-identical to before.
- `DataRegistry(KeyedRegistry[ProviderType, Any])` keeps its capability API + the sync/async `*_get_with_fallback` twins (now sharing a `_require()` helper). `LLMRegistry(KeyedRegistry[Role, LLMProvider])` keeps its role API. Public surfaces unchanged.
- `provider_catalog`: the two `discover_*` are now thin wrappers over one `_discover(group, builtins, kind, extract_meta)` helper with per-kind metadata extractors.

**961 passed, pyright 0 errors, ruff/docs clean, coverage 81%.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)