### PR TITLE
feat: complete KIS DerivativesProvider against live 국내선물옵션 API

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,12 +74,15 @@ entry-point group.
 `appsecret` (`ProviderConfig` grows a `secret_env` alongside `api_key_env`; the
 registry builder resolves both and passes them as `api_key`/`api_secret`). The
 adapter exchanges them for a short-lived OAuth bearer token cached at
-`~/.qracer/kis_token.json` (KIS issues tokens at most once per minute). Its stock
-price/OHLCV endpoints are verified against the live API; the 국내선물옵션
-(futures/option) `tr_id`s and response fields are mapped from the KIS portal docs
-and should be smoke-tested against a live account, since they can vary by account
-tier. As a `PriceProvider` it sits above DART/yfinance for Korean codes (priority
-20) and fails fast on non-6-digit tickers so US symbols fall through to yfinance.
+`~/.qracer/kis_token.json` (KIS issues tokens at most once per minute). All its
+endpoints are verified against the live API: stock price/OHLCV, plus the
+국내선물옵션 boards behind `DerivativesProvider` — `get_futures_quote` (contract
+quote in the response `output1`; `output2` is the underlying index),
+`get_option_chain` (`display-board-callput`, calls in `output1` / puts in `output2`,
+with greeks + IV + open interest), and the discovery helpers `get_futures_board`
+and `list_option_expiries` that surface the codes/expiries those take. As a
+`PriceProvider` it sits above DART/yfinance for Korean codes (priority 20) and fails
+fast on non-6-digit tickers so US symbols fall through to yfinance.
 
 ## Configuration (`.qracer/`)
 

--- a/qracer/data/kis_adapter.py
+++ b/qracer/data/kis_adapter.py
@@ -7,15 +7,18 @@ adapter needs *two* credentials (wired through ``ProviderConfig.api_key_env`` +
 ``secret_env``). It provides two capabilities, keyed by KRX contract code:
 
 - PriceProvider       → current price + daily OHLCV for a 6-digit KRX stock code
-- DerivativesProvider → futures quotes and option chains (국내선물옵션)
+- DerivativesProvider → futures quotes and option chains (국내선물옵션), plus
+                        ``get_futures_board`` / ``list_option_expiries`` for
+                        discovering the contract codes and expiries they take
 
 Tokens are issued at most once per minute per app, so the access token is cached in
 memory and on disk (``~/.qracer/kis_token.json``) and refreshed only near expiry.
 
-The stock endpoints (``inquire-price`` / ``inquire-daily-itemchartprice``) are verified
-against the live API. The 국내선물옵션 endpoints' exact ``tr_id`` / response fields are
-mapped from the KIS portal docs and should be smoke-tested against a live account
-(they can vary by account type); see docs/architecture.md.
+All endpoints (stock ``inquire-price`` / ``inquire-daily-itemchartprice`` and the
+국내선물옵션 ``inquire-price`` / ``display-board-*`` boards) are verified against the
+live API. Note the futures quote lives in the response ``output1`` (``output2`` is the
+underlying index), and the option board returns calls in ``output1`` and puts in
+``output2``.
 """
 
 from __future__ import annotations
@@ -45,11 +48,13 @@ logger = logging.getLogger(__name__)
 _REAL_URL = "https://openapi.koreainvestment.com:9443"
 _MOCK_URL = "https://openapivts.koreainvestment.com:29443"
 
-# tr_id codes (per KIS portal). Stock ones are live-verified; derivatives are from docs.
+# tr_id codes (per KIS portal), all live-verified against the real API.
 _TR_STOCK_PRICE = "FHKST01010100"  # 주식현재가 시세
 _TR_STOCK_DAILY = "FHKST03010100"  # 주식일별 기간별시세
-_TR_FUT_PRICE = "FHMIF10000000"  # 선물옵션 시세
-_TR_OPT_BOARD = "FHPIF05030100"  # 국내옵션전광판 콜풋
+_TR_FUT_PRICE = "FHMIF10000000"  # 선물옵션 시세 (single contract)
+_TR_FUT_BOARD = "FHPIF05030200"  # 국내선물 전광판 (contract list)
+_TR_OPT_CALLPUT = "FHPIF05030100"  # 국내옵션전광판 콜풋 (chain)
+_TR_OPT_MONTHS = "FHPIO056104C0"  # 국내옵션전광판 월물 리스트
 
 # Refresh the token when fewer than this many seconds of its life remain.
 _TOKEN_REFRESH_MARGIN = 300
@@ -128,25 +133,36 @@ def _parse_ohlcv(output2: list[dict]) -> list[OHLCV]:
     return bars
 
 
+def _expiry_from_name(name: object) -> str | None:
+    """Extract a ``YYYYMM`` contract month from an HTS name like ``미니F 202608``."""
+    text = str(name or "")
+    for token in text.replace("(", " ").replace(")", " ").split():
+        if len(token) == 6 and token.isdigit():
+            return token
+    return None
+
+
 def _parse_futures(output: dict, code: str) -> FuturesQuote:
-    """Map a 선물옵션 ``inquire-price`` ``output`` object to a FuturesQuote."""
-    price = _to_float(output.get("futs_prpr")) or _to_float(output.get("stck_prpr")) or 0.0
+    """Map a 선물 ``inquire-price`` ``output1`` (or 전광판 row) to a FuturesQuote."""
+    name = output.get("hts_kor_isnm")
     return FuturesQuote(
         code=code,
-        price=price,
-        underlying=output.get("hts_kor_isnm") or None,
-        change=_to_float(output.get("futs_prdy_vrss") or output.get("prdy_vrss")),
-        change_pct=_to_float(output.get("prdy_ctrt")),
+        price=_to_float(output.get("futs_prpr")) or 0.0,
+        underlying=name or None,
+        expiry=_expiry_from_name(name),
+        change=_to_float(output.get("futs_prdy_vrss")),
+        change_pct=_to_float(output.get("futs_prdy_ctrt")),
         volume=_to_int(output.get("acml_vol")),
-        open_interest=_to_int(output.get("hts_otst_stpl_qty") or output.get("otst_stpl_qty")),
+        open_interest=_to_int(output.get("hts_otst_stpl_qty")),
+        basis=_to_float(output.get("basis")),
     )
 
 
 def _parse_option_row(row: dict, right: str) -> OptionQuote | None:
-    """Map one row of an 옵션전광판 payload to an OptionQuote (None if unparseable)."""
-    code = (row.get("optn_shrn_iscd") or row.get("mksc_shrn_iscd") or "").strip()
-    price = _to_float(row.get("optn_prpr") or row.get("stck_prpr"))
-    strike = _to_float(row.get("acpr") or row.get("optn_strk_prc"))
+    """Map one row of an 옵션전광판 콜풋 payload to an OptionQuote (None if unparseable)."""
+    code = (row.get("optn_shrn_iscd") or "").strip()
+    price = _to_float(row.get("optn_prpr"))
+    strike = _to_float(row.get("acpr"))
     if not code or price is None or strike is None:
         return None
     return OptionQuote(
@@ -154,27 +170,25 @@ def _parse_option_row(row: dict, right: str) -> OptionQuote | None:
         right=right,
         strike=strike,
         price=price,
-        change=_to_float(row.get("optn_prdy_vrss") or row.get("prdy_vrss")),
+        change=_to_float(row.get("optn_prdy_vrss")),
         volume=_to_int(row.get("acml_vol")),
-        open_interest=_to_int(row.get("hts_otst_stpl_qty") or row.get("otst_stpl_qty")),
-        implied_vol=_to_float(row.get("hts_ints_vltl") or row.get("optn_ints_vltl")),
-        delta=_to_float(row.get("delta")),
-        gamma=_to_float(row.get("gama") or row.get("gamma")),
+        open_interest=_to_int(row.get("hts_otst_stpl_qty")),
+        implied_vol=_to_float(row.get("hts_ints_vltl")),
+        delta=_to_float(row.get("delta_val")),
+        gamma=_to_float(row.get("gama")),
         theta=_to_float(row.get("theta")),
         vega=_to_float(row.get("vega")),
+        rho=_to_float(row.get("rho")),
     )
 
 
 def _parse_option_chain(payload: dict, underlying: str, expiry: str | None) -> OptionChain:
-    """Map an 옵션전광판 콜풋 payload (call rows + put rows) to an OptionChain.
+    """Map an 옵션전광판 콜풋 payload to an OptionChain (``output1`` calls, ``output2`` puts).
 
-    KIS returns calls and puts in two arrays; field names differ by account tier,
-    so both common spellings are accepted and unparseable rows are dropped.
+    Unparseable rows (e.g. header/blank strikes) are dropped rather than raising.
     """
-    calls_raw = payload.get("output1") or payload.get("call") or []
-    puts_raw = payload.get("output2") or payload.get("put") or []
-    calls = [q for row in calls_raw if (q := _parse_option_row(row, "C"))]
-    puts = [q for row in puts_raw if (q := _parse_option_row(row, "P"))]
+    calls = [q for row in (payload.get("output1") or []) if (q := _parse_option_row(row, "C"))]
+    puts = [q for row in (payload.get("output2") or []) if (q := _parse_option_row(row, "P"))]
     return OptionChain(underlying=underlying, expiry=expiry, calls=calls, puts=puts)
 
 
@@ -330,31 +344,85 @@ class KisAdapter:
     # -- DerivativesProvider -------------------------------------------------
 
     async def get_futures_quote(self, code: str) -> FuturesQuote:
-        """Quote for a single futures contract (e.g. a KOSPI 200 futures month)."""
+        """Quote for a single futures contract by KIS code (e.g. ``A05608``).
+
+        The contract quote is in the response ``output1`` object (``output2`` holds
+        the underlying index). Discover valid codes with :meth:`get_futures_board`.
+        """
         contract = code.strip().upper()
         payload = await self._get(
             "/uapi/domestic-futureoption/v1/quotations/inquire-price",
             _TR_FUT_PRICE,
             {"FID_COND_MRKT_DIV_CODE": "F", "FID_INPUT_ISCD": contract},
         )
-        return _parse_futures(payload.get("output") or {}, contract)
+        return _parse_futures(payload.get("output1") or {}, contract)
 
-    async def get_option_chain(self, underlying: str, expiry: str | None = None) -> OptionChain:
-        """Call/put option chain for an underlying (optionally a specific expiry ``YYYYMM``)."""
-        target = underlying.strip().upper()
-        params = {
-            "FID_COND_MRKT_DIV_CODE": "O",
-            "FID_COND_SCR_DIV_CODE": "20503",
-            "FID_MRKT_CLS_CODE": target,
-        }
-        if expiry:
-            params["FID_INPUT_DATE_1"] = expiry
+    async def get_futures_board(self, market: str = "MKI") -> list[FuturesQuote]:
+        """All listed futures contracts on a board (``MKI`` = KOSPI 200 mini futures).
+
+        Useful for discovering the contract codes that :meth:`get_futures_quote`
+        expects.
+        """
+        payload = await self._get(
+            "/uapi/domestic-futureoption/v1/quotations/display-board-futures",
+            _TR_FUT_BOARD,
+            {
+                "FID_COND_MRKT_DIV_CODE": "F",
+                "FID_COND_SCR_DIV_CODE": "20503",
+                "FID_COND_MRKT_CLS_CODE": market,
+            },
+        )
+        return [
+            _parse_futures(row, (row.get("futs_shrn_iscd") or "").strip())
+            for row in (payload.get("output") or [])
+            if row.get("futs_shrn_iscd")
+        ]
+
+    async def list_option_expiries(self) -> list[str]:
+        """Available option expiry months (``YYYYMM``), nearest first."""
         payload = await self._get(
             "/uapi/domestic-futureoption/v1/quotations/display-board-option-list",
-            _TR_OPT_BOARD,
-            params,
+            _TR_OPT_MONTHS,
+            {
+                "FID_COND_SCR_DIV_CODE": "509",
+                "FID_COND_MRKT_DIV_CODE": "",
+                "FID_COND_MRKT_CLS_CODE": "",
+            },
         )
-        return _parse_option_chain(payload, target, expiry)
+        months = [
+            (row.get("mtrt_yymm") or "").strip()
+            for row in (payload.get("output") or [])
+            if (row.get("mtrt_yymm") or "").strip()
+        ]
+        return sorted(months)
+
+    async def get_option_chain(
+        self, underlying: str = "KOSPI200", expiry: str | None = None
+    ) -> OptionChain:
+        """Call/put option chain for a given expiry month (``YYYYMM``).
+
+        KIS index options are always on the KOSPI 200; ``underlying`` is carried
+        through onto the returned chain for labelling. When ``expiry`` is omitted
+        the nearest listed expiry is used.
+        """
+        if not expiry:
+            expiries = await self.list_option_expiries()
+            if not expiries:
+                raise RuntimeError("KIS returned no option expiries")
+            expiry = expiries[0]
+        payload = await self._get(
+            "/uapi/domestic-futureoption/v1/quotations/display-board-callput",
+            _TR_OPT_CALLPUT,
+            {
+                "FID_COND_MRKT_DIV_CODE": "O",
+                "FID_COND_SCR_DIV_CODE": "20503",
+                "FID_MRKT_CLS_CODE": "CO",  # calls -> output1
+                "FID_MTRT_CNT": expiry,
+                "FID_MRKT_CLS_CODE1": "PO",  # puts -> output2
+                "FID_COND_MRKT_CLS_CODE": "",  # required key; empty is accepted
+            },
+        )
+        return _parse_option_chain(payload, underlying.strip().upper(), expiry)
 
     async def aclose(self) -> None:
         await self._client.aclose()

--- a/qracer/data/providers.py
+++ b/qracer/data/providers.py
@@ -109,6 +109,7 @@ class OptionQuote:
     gamma: float | None = None
     theta: float | None = None
     vega: float | None = None
+    rho: float | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/data/test_kis_adapter.py
+++ b/tests/data/test_kis_adapter.py
@@ -144,20 +144,25 @@ class TestParseOhlcv:
 
 class TestParseDerivatives:
     def test_futures(self) -> None:
+        # Field names match a live inquire-price output1 / display-board-futures row.
         out = {
-            "futs_prpr": "412.50",
-            "hts_kor_isnm": "KOSPI200 F 202609",
-            "futs_prdy_vrss": "-3.20",
-            "prdy_ctrt": "-0.77",
-            "acml_vol": "120000",
-            "hts_otst_stpl_qty": "300000",
+            "futs_prpr": "1036.28",
+            "hts_kor_isnm": "미니F 202608",
+            "futs_prdy_vrss": "172.70",
+            "futs_prdy_ctrt": "20.00",
+            "acml_vol": "114838",
+            "hts_otst_stpl_qty": "100264",
+            "basis": "0.85",
         }
-        q = _parse_futures(out, "101W09")
-        assert q.code == "101W09" and q.price == 412.5
-        assert q.open_interest == 300000 and q.volume == 120000
-        assert q.change == -3.2
+        q = _parse_futures(out, "A05608")
+        assert q.code == "A05608" and q.price == 1036.28
+        assert q.open_interest == 100264 and q.volume == 114838
+        assert q.change == 172.7 and q.change_pct == 20.0
+        assert q.basis == 0.85
+        assert q.expiry == "202608"  # extracted from the HTS name
 
     def test_option_chain_splits_calls_and_puts(self) -> None:
+        # output1 = calls, output2 = puts (live display-board-callput shape).
         payload = {
             "output1": [
                 {
@@ -166,7 +171,9 @@ class TestParseDerivatives:
                     "acpr": "320.0",
                     "acml_vol": "500",
                     "hts_otst_stpl_qty": "1200",
-                    "delta": "0.55",
+                    "hts_ints_vltl": "18.5",
+                    "delta_val": "0.55",
+                    "gama": "0.01",
                 },
             ],
             "output2": [
@@ -175,6 +182,7 @@ class TestParseDerivatives:
                     "optn_prpr": "4.20",
                     "acpr": "320.0",
                     "acml_vol": "400",
+                    "delta_val": "-0.45",
                 },
                 {"optn_shrn_iscd": "", "optn_prpr": "1", "acpr": "1"},  # dropped: no code
             ],
@@ -183,7 +191,9 @@ class TestParseDerivatives:
         assert chain.underlying == "KOSPI200" and chain.expiry == "202609"
         assert len(chain.calls) == 1 and chain.calls[0].right == "C"
         assert chain.calls[0].strike == 320.0 and chain.calls[0].delta == 0.55
+        assert chain.calls[0].implied_vol == 18.5 and chain.calls[0].gamma == 0.01
         assert len(chain.puts) == 1 and chain.puts[0].right == "P"
+        assert chain.puts[0].delta == -0.45
 
 
 # ---------------------------------------------------------------------------
@@ -302,17 +312,52 @@ class TestPriceProvider:
 
 
 class TestDerivativesProvider:
-    async def test_get_futures_quote(self, tmp_path: Path) -> None:
+    async def test_get_futures_quote_reads_output1(self, tmp_path: Path) -> None:
+        # The contract quote is in output1; output2 is the underlying index.
         body = {
             "rt_cd": "0",
-            "output": {"futs_prpr": "412.50", "acml_vol": "120000", "hts_otst_stpl_qty": "300000"},
+            "output1": {
+                "futs_prpr": "1036.28",
+                "acml_vol": "114838",
+                "hts_otst_stpl_qty": "100264",
+                "basis": "0.85",
+            },
+            "output2": {"bstp_nmix_prpr": "6595.45"},
         }
-        handler = _router({"domestic-futureoption/v1/quotations/inquire-price": body})
+        handler = _router({"quotations/inquire-price": body})
         adapter = _adapter(handler, tmp_path)
-        q = await adapter.get_futures_quote("101W09")
-        assert q.price == 412.5 and q.open_interest == 300000
+        q = await adapter.get_futures_quote("A05608")
+        assert q.price == 1036.28 and q.open_interest == 100264 and q.basis == 0.85
 
-    async def test_get_option_chain(self, tmp_path: Path) -> None:
+    async def test_get_futures_board(self, tmp_path: Path) -> None:
+        body = {
+            "rt_cd": "0",
+            "output": [
+                {
+                    "futs_shrn_iscd": "A05608",
+                    "hts_kor_isnm": "미니F 202608",
+                    "futs_prpr": "1036.28",
+                    "hts_otst_stpl_qty": "100264",
+                },
+                {"futs_shrn_iscd": "", "futs_prpr": "0"},  # dropped: no code
+            ],
+        }
+        handler = _router({"display-board-futures": body})
+        adapter = _adapter(handler, tmp_path)
+        board = await adapter.get_futures_board()
+        assert len(board) == 1
+        assert board[0].code == "A05608" and board[0].expiry == "202608"
+
+    async def test_list_option_expiries_sorted(self, tmp_path: Path) -> None:
+        body = {
+            "rt_cd": "0",
+            "output": [{"mtrt_yymm": "202609"}, {"mtrt_yymm": "202608"}, {"mtrt_yymm": ""}],
+        }
+        handler = _router({"display-board-option-list": body})
+        adapter = _adapter(handler, tmp_path)
+        assert await adapter.list_option_expiries() == ["202608", "202609"]
+
+    async def test_get_option_chain_explicit_expiry(self, tmp_path: Path) -> None:
         body = {
             "rt_cd": "0",
             "output1": [
@@ -322,8 +367,25 @@ class TestDerivativesProvider:
                 {"optn_shrn_iscd": "301AB320", "optn_prpr": "4.2", "acpr": "320", "acml_vol": "4"},
             ],
         }
-        handler = _router({"display-board-option-list": body})
+        handler = _router({"display-board-callput": body})
         adapter = _adapter(handler, tmp_path)
-        chain = await adapter.get_option_chain("KOSPI200", "202609")
+        chain = await adapter.get_option_chain(expiry="202609")
+        assert chain.expiry == "202609"
         assert len(chain.calls) == 1 and len(chain.puts) == 1
         assert chain.calls[0].strike == 320.0
+
+    async def test_get_option_chain_auto_discovers_nearest_expiry(self, tmp_path: Path) -> None:
+        # No expiry -> adapter first lists months, then queries the nearest.
+        months = {"rt_cd": "0", "output": [{"mtrt_yymm": "202609"}, {"mtrt_yymm": "202608"}]}
+        chain_body = {
+            "rt_cd": "0",
+            "output1": [{"optn_shrn_iscd": "C1", "optn_prpr": "1", "acpr": "320"}],
+            "output2": [],
+        }
+        handler = _router(
+            {"display-board-option-list": months, "display-board-callput": chain_body}
+        )
+        adapter = _adapter(handler, tmp_path)
+        chain = await adapter.get_option_chain()
+        assert chain.expiry == "202608"  # nearest of the listed months
+        assert len(chain.calls) == 1


### PR DESCRIPTION
## What

Follow-up to #187. The initial KIS derivatives mapping was scaffolded from portal docs and flagged for live verification. This PR **verifies every derivatives endpoint against the live KIS API** and fixes the mapping, plus adds contract/expiry discovery so the derivatives are actually usable end-to-end.

## Changes

- **`get_futures_quote`** — the contract quote is in the response `output1` (`output2` is the underlying index). Maps the real fields (`futs_prpr`, `futs_prdy_vrss`/`futs_prdy_ctrt`, `hts_otst_stpl_qty`, `basis`) and extracts the `YYYYMM` expiry from the HTS name.
- **`get_option_chain`** — corrected to `display-board-callput` (`FHPIF05030100`) with the full required param set (`FID_MRKT_CLS_CODE=CO`/`FID_MRKT_CLS_CODE1=PO`, `FID_MTRT_CNT`, and the required-but-empty `FID_COND_MRKT_CLS_CODE`). Calls come in `output1`, puts in `output2`, with greeks (`delta_val`/`gama`/`theta`/`vega`/`rho`), implied vol (`hts_ints_vltl`), and open interest. Auto-discovers the nearest expiry when none is given.
- **Discovery helpers** (so callers can find valid codes/expiries): `get_futures_board` (lists contracts + codes) and `list_option_expiries` (available `YYYYMM` months).
- `OptionQuote` gains `rho`.
- Mock tests updated to the **real** response shapes; new tests for the discovery helpers and auto-expiry path. Docs refreshed (derivatives now live-verified).

## Live verification

Run against the live API with the issued credentials:

```
get_futures_board() -> 6 contracts
  A05608 '미니F 202608' px=1036.28 chg%=20.0 OI=100264 exp=202608
get_futures_quote('A05608') -> px=1036.28 chg=172.7 OI=100264 basis=0.85 exp=202608
list_option_expiries() -> ['202608','202609','202610','202611','202612','202701']
get_option_chain(expiry=202608) -> 100 calls / 100 puts
  sample call: B01608B91 K=1472.5 px=0.82 IV=92.06 delta=0.0 OI=68
```

## Checks

Full suite **1089 passed**, `kis_adapter.py` 91% coverage, total **81.92%**, pyright **0**, ruff clean, docs validation passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)