### PR TITLE
feat: route Telegram free-text messages to ConversationEngine (#165)

### DIFF
--- a/qracer/cli.py
+++ b/qracer/cli.py
@@ -776,6 +776,43 @@ def serve(check_interval: int) -> None:
     # Real-time price streaming (WebSocket) — falls back to REST polling if unavailable.
     streaming_adapter = _build_streaming_adapter(config)
 
+    # Conversation engine for Telegram free-text queries.
+    conversation_engine = None
+    if telegram_poller is not None:
+        import uuid
+
+        from qracer.conversation.engine import ConversationEngine
+        from qracer.memory.fact_store import FactStore
+        from qracer.memory.memory_searcher import MemorySearcher
+        from qracer.memory.session_logger import SessionLogger
+
+        sessions_dir = _user_dir() / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        bot_session_id = f"bot-{uuid.uuid4().hex[:12]}"
+        bot_session_logger = SessionLogger(sessions_dir / f"{bot_session_id}.jsonl")
+
+        summaries_dir = _user_dir() / "summaries"
+        summaries_dir.mkdir(parents=True, exist_ok=True)
+        memory_searcher = MemorySearcher(_user_dir() / "memory_index.duckdb")
+        memory_searcher.index_directory(summaries_dir)
+
+        fact_store = FactStore(_user_dir() / "fact_store.duckdb")
+        reports_dir = _user_dir() / "reports"
+
+        conversation_engine = ConversationEngine(
+            llm_registry,
+            data_registry,
+            max_iterations=app_cfg.max_iterations,
+            confidence_threshold=app_cfg.confidence_threshold,
+            session_logger=bot_session_logger,
+            report_dir=reports_dir,
+            language=app_cfg.language,
+            memory_searcher=memory_searcher,
+            summaries_dir=summaries_dir,
+            fact_store=fact_store,
+            context_path=_user_dir() / "context.json",
+        )
+
     server = Server(
         alert_monitor,
         task_executor,
@@ -785,6 +822,7 @@ def serve(check_interval: int) -> None:
         briefing_scheduler=briefing_scheduler,
         telegram_poller=telegram_poller,
         streaming_adapter=streaming_adapter,
+        conversation_engine=conversation_engine,
         tick_interval=1.0,
     )
 
@@ -805,7 +843,10 @@ def serve(check_interval: int) -> None:
             f" cooldown={app_cfg.alert_cooldown_minutes}m"
         )
     if telegram_poller is not None:
-        click.echo("  Telegram bot: receiving commands (try /help in chat)")
+        if conversation_engine is not None:
+            click.echo("  Telegram bot: commands + conversational queries (try /help in chat)")
+        else:
+            click.echo("  Telegram bot: receiving commands (try /help in chat)")
     if agent_monitor is not None:
         scheduled = sum(
             1 for a in agent_store.agents if a.enabled and a.trigger_type.value != "manual"

--- a/qracer/notifications/bot_commands.py
+++ b/qracer/notifications/bot_commands.py
@@ -23,10 +23,13 @@ class BotCommandHandler:
         alert_store: AlertStore,
         task_store: TaskStore,
         status_provider: Callable[[], str],
+        *,
+        conversation_enabled: bool = False,
     ) -> None:
         self._alert_store = alert_store
         self._task_store = task_store
         self._status_provider = status_provider
+        self._conversation_enabled = conversation_enabled
 
     def dispatch(self, command: BotCommand) -> str:
         """Route a command to its handler; handlers return the reply text."""
@@ -50,18 +53,21 @@ class BotCommandHandler:
             )
         return f"Unknown command: /{action}. Try /help."
 
-    @staticmethod
-    def _cmd_help() -> str:
-        return (
-            "qracer bot commands:\n"
-            "/status — server status and uptime\n"
-            "/alerts — list active price alerts\n"
-            "/alert TICKER above|below PRICE — create a price alert\n"
-            "/tasks — list scheduled tasks\n"
-            "/schedule ACTION TICKER SCHEDULE — schedule a task\n"
-            "    e.g. /schedule analyze AAPL every 1h\n"
-            "/help — show this message"
-        )
+    def _cmd_help(self) -> str:
+        lines = [
+            "qracer bot commands:",
+            "/status — server status and uptime",
+            "/alerts — list active price alerts",
+            "/alert TICKER above|below PRICE — create a price alert",
+            "/tasks — list scheduled tasks",
+            "/schedule ACTION TICKER SCHEDULE — schedule a task",
+            "    e.g. /schedule analyze AAPL every 1h",
+            "/help — show this message",
+        ]
+        if self._conversation_enabled:
+            lines.append("")
+            lines.append("You can also type any question directly (without a /) to query the AI.")
+        return "\n".join(lines)
 
     def _cmd_alerts(self) -> str:
         alerts = self._alert_store.get_active()

--- a/qracer/notifications/telegram_poller.py
+++ b/qracer/notifications/telegram_poller.py
@@ -29,6 +29,13 @@ _DEFAULT_MESSAGE_CHAR_LIMIT = 4000
 
 
 @dataclass(frozen=True)
+class BotMessage:
+    """A free-text (non-command) message from a Telegram chat."""
+
+    text: str
+
+
+@dataclass(frozen=True)
 class BotCommand:
     """A parsed bot command from a Telegram message.
 
@@ -121,9 +128,18 @@ class TelegramBotPoller:
         Network and API errors are logged and converted to an empty list
         — the caller is expected to retry on the next tick.
         """
-        return await asyncio.to_thread(self._poll_sync)
+        commands, _ = await asyncio.to_thread(self._fetch_updates)
+        return commands
 
-    def _poll_sync(self) -> list[BotCommand]:
+    async def poll_all(self) -> tuple[list[BotCommand], list[BotMessage]]:
+        """Long-poll Telegram for both commands and free-text messages.
+
+        Like :meth:`poll` but also returns non-command text messages so
+        the caller can route them to a conversation engine.
+        """
+        return await asyncio.to_thread(self._fetch_updates)
+
+    def _fetch_updates(self) -> tuple[list[BotCommand], list[BotMessage]]:
         url = f"{_TELEGRAM_API}/bot{self._bot_token}/getUpdates"
         params: dict[str, Any] = {
             "timeout": self._timeout,
@@ -137,26 +153,27 @@ class TelegramBotPoller:
             with urllib.request.urlopen(full_url, timeout=self._timeout + 5) as resp:
                 if resp.status != 200:
                     logger.warning("Telegram getUpdates returned status %s", resp.status)
-                    return []
+                    return [], []
                 payload = json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
             logger.error("Telegram getUpdates failed (HTTP %s): %s", exc.code, exc.reason)
-            return []
+            return [], []
         except urllib.error.URLError as exc:
             logger.error("Telegram getUpdates failed (network): %s", exc.reason)
-            return []
+            return [], []
         except (json.JSONDecodeError, ValueError) as exc:
             logger.error("Telegram getUpdates returned invalid JSON: %s", exc)
-            return []
+            return [], []
 
         if not isinstance(payload, dict) or not payload.get("ok"):
             logger.warning(
                 "Telegram getUpdates returned ok=false: %s",
                 payload.get("description") if isinstance(payload, dict) else payload,
             )
-            return []
+            return [], []
 
         commands: list[BotCommand] = []
+        messages: list[BotMessage] = []
         max_update_id = -1
         for update in payload.get("result", []):
             update_id = update.get("update_id")
@@ -179,11 +196,13 @@ class TelegramBotPoller:
             cmd = BotCommand.parse(text)
             if cmd is not None:
                 commands.append(cmd)
+            elif text.strip():
+                messages.append(BotMessage(text=text.strip()))
 
         if max_update_id >= 0:
             self._offset = max_update_id + 1
 
-        return commands
+        return commands, messages
 
     async def send_reply(self, text: str) -> bool:
         """Send a plain-text reply to the authorised chat.

--- a/qracer/server.py
+++ b/qracer/server.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from qracer.agent_monitor import AgentMonitor
 from qracer.alert_monitor import AlertMonitor
@@ -20,8 +20,11 @@ from qracer.data.providers import StreamingProvider
 from qracer.notifications.bot_commands import BotCommandHandler
 from qracer.notifications.providers import Notification, NotificationCategory
 from qracer.notifications.registry import NotificationRegistry
-from qracer.notifications.telegram_poller import BotCommand, TelegramBotPoller
+from qracer.notifications.telegram_poller import BotCommand, BotMessage, TelegramBotPoller
 from qracer.task_executor import TaskExecutor
+
+if TYPE_CHECKING:
+    from qracer.conversation.engine import ConversationEngine
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +53,7 @@ class Server:
         briefing_scheduler: "BriefingScheduler | None" = None,
         telegram_poller: TelegramBotPoller | None = None,
         streaming_adapter: StreamingProvider | None = None,
+        conversation_engine: "ConversationEngine | None" = None,
         tick_interval: float = 1.0,
     ) -> None:
         self._alert_monitor = alert_monitor
@@ -60,6 +64,7 @@ class Server:
         self._notifications = notifications or NotificationRegistry()
         self._telegram_poller = telegram_poller
         self._streaming_adapter = streaming_adapter
+        self._conversation_engine = conversation_engine
         self._tick_interval = tick_interval
         self._shutdown_event = asyncio.Event()
         self._started_at: float | None = None
@@ -78,7 +83,12 @@ class Server:
             self._monitors.append((briefing_scheduler, self._handle_briefing_result))
 
         # Inbound Telegram bot commands are a separate concern from the tick loop.
-        self._bot = BotCommandHandler(alert_monitor.store, task_executor.store, self._status_text)
+        self._bot = BotCommandHandler(
+            alert_monitor.store,
+            task_executor.store,
+            self._status_text,
+            conversation_enabled=conversation_engine is not None,
+        )
 
     async def run(self) -> None:
         """Main loop — runs until shutdown() is called."""
@@ -169,12 +179,19 @@ class Server:
 
         if self._telegram_poller is not None:
             try:
-                commands = await self._telegram_poller.poll()
+                if self._conversation_engine is not None:
+                    commands, messages = await self._telegram_poller.poll_all()
+                else:
+                    commands = await self._telegram_poller.poll()
+                    messages = []
             except Exception:
                 logger.debug("Telegram poll failed", exc_info=True)
                 commands = []
+                messages = []
             for command in commands:
                 await self._handle_bot_command(command)
+            for message in messages:
+                await self._handle_bot_message(message)
 
     # -- per-monitor result handlers ------------------------------------
 
@@ -224,6 +241,21 @@ class Server:
             reply = f"Error handling /{command.action}: {exc}"
         if reply and self._telegram_poller is not None:
             await self._telegram_poller.send_reply(reply)
+
+    async def _handle_bot_message(self, message: BotMessage) -> None:
+        """Route a free-text Telegram message through ConversationEngine."""
+        if self._conversation_engine is None or self._telegram_poller is None:
+            return
+        text = message.text
+        if not text:
+            return
+        await self._telegram_poller.send_reply("Analyzing your query...")
+        try:
+            response = await self._conversation_engine.query(text)
+            await self._telegram_poller.send_reply(response.text)
+        except Exception as exc:
+            logger.exception("Conversation query failed: %s", text[:80])
+            await self._telegram_poller.send_reply(f"Query failed: {exc}")
 
     def _dispatch_bot_command(self, command: BotCommand) -> str:
         """Route a bot command to a reply (delegates to the BotCommandHandler)."""

--- a/tests/notifications/test_telegram_poller.py
+++ b/tests/notifications/test_telegram_poller.py
@@ -362,9 +362,7 @@ class TestTelegramBotPollerPollAll:
     def poller(self) -> TelegramBotPoller:
         return TelegramBotPoller(bot_token="tok", chat_id="999", timeout=1)
 
-    async def test_poll_all_returns_commands_and_messages(
-        self, poller: TelegramBotPoller
-    ) -> None:
+    async def test_poll_all_returns_commands_and_messages(self, poller: TelegramBotPoller) -> None:
         payload = {
             "ok": True,
             "result": [
@@ -398,9 +396,7 @@ class TestTelegramBotPollerPollAll:
         assert len(messages) == 1
         assert messages[0].text == "hello"
 
-    async def test_poll_all_skips_whitespace_only_messages(
-        self, poller: TelegramBotPoller
-    ) -> None:
+    async def test_poll_all_skips_whitespace_only_messages(self, poller: TelegramBotPoller) -> None:
         payload = {
             "ok": True,
             "result": [_make_update(1, 999, "   ")],
@@ -411,9 +407,7 @@ class TestTelegramBotPollerPollAll:
 
         assert messages == []
 
-    async def test_poll_all_filters_unauthorised_chats(
-        self, poller: TelegramBotPoller
-    ) -> None:
+    async def test_poll_all_filters_unauthorised_chats(self, poller: TelegramBotPoller) -> None:
         payload = {
             "ok": True,
             "result": [
@@ -436,9 +430,7 @@ class TestTelegramBotPollerPollAll:
         assert commands == []
         assert messages == []
 
-    async def test_poll_still_returns_only_commands(
-        self, poller: TelegramBotPoller
-    ) -> None:
+    async def test_poll_still_returns_only_commands(self, poller: TelegramBotPoller) -> None:
         payload = {
             "ok": True,
             "result": [

--- a/tests/notifications/test_telegram_poller.py
+++ b/tests/notifications/test_telegram_poller.py
@@ -11,6 +11,7 @@ import pytest
 
 from qracer.notifications.telegram_poller import (
     BotCommand,
+    BotMessage,
     TelegramBotPoller,
 )
 
@@ -334,3 +335,120 @@ class TestTelegramBotPollerReply:
         with patch(target, side_effect=urllib.error.URLError("offline")):
             ok = await poller.send_reply("hello")
         assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# BotMessage
+# ---------------------------------------------------------------------------
+
+
+class TestBotMessage:
+    def test_frozen(self) -> None:
+        msg = BotMessage(text="hello")
+        assert msg.text == "hello"
+
+    def test_equality(self) -> None:
+        assert BotMessage(text="hi") == BotMessage(text="hi")
+        assert BotMessage(text="hi") != BotMessage(text="bye")
+
+
+# ---------------------------------------------------------------------------
+# poll_all — commands + free-text messages
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramBotPollerPollAll:
+    @pytest.fixture()
+    def poller(self) -> TelegramBotPoller:
+        return TelegramBotPoller(bot_token="tok", chat_id="999", timeout=1)
+
+    async def test_poll_all_returns_commands_and_messages(
+        self, poller: TelegramBotPoller
+    ) -> None:
+        payload = {
+            "ok": True,
+            "result": [
+                _make_update(10, 999, "/status"),
+                _make_update(11, 999, "What is the outlook for AAPL?"),
+                _make_update(12, 999, "/alerts"),
+            ],
+        }
+        target = "qracer.notifications.telegram_poller.urllib.request.urlopen"
+        with patch(target, return_value=_mock_response(payload)):
+            commands, messages = await poller.poll_all()
+
+        assert len(commands) == 2
+        assert commands[0].action == "status"
+        assert commands[1].action == "alerts"
+        assert len(messages) == 1
+        assert messages[0].text == "What is the outlook for AAPL?"
+        assert poller.offset == 13
+
+    async def test_poll_all_strips_whitespace_from_messages(
+        self, poller: TelegramBotPoller
+    ) -> None:
+        payload = {
+            "ok": True,
+            "result": [_make_update(1, 999, "  hello  ")],
+        }
+        target = "qracer.notifications.telegram_poller.urllib.request.urlopen"
+        with patch(target, return_value=_mock_response(payload)):
+            _, messages = await poller.poll_all()
+
+        assert len(messages) == 1
+        assert messages[0].text == "hello"
+
+    async def test_poll_all_skips_whitespace_only_messages(
+        self, poller: TelegramBotPoller
+    ) -> None:
+        payload = {
+            "ok": True,
+            "result": [_make_update(1, 999, "   ")],
+        }
+        target = "qracer.notifications.telegram_poller.urllib.request.urlopen"
+        with patch(target, return_value=_mock_response(payload)):
+            _, messages = await poller.poll_all()
+
+        assert messages == []
+
+    async def test_poll_all_filters_unauthorised_chats(
+        self, poller: TelegramBotPoller
+    ) -> None:
+        payload = {
+            "ok": True,
+            "result": [
+                _make_update(1, 999, "legit question"),
+                _make_update(2, 1234, "sneaky message"),
+            ],
+        }
+        target = "qracer.notifications.telegram_poller.urllib.request.urlopen"
+        with patch(target, return_value=_mock_response(payload)):
+            _, messages = await poller.poll_all()
+
+        assert len(messages) == 1
+        assert messages[0].text == "legit question"
+
+    async def test_poll_all_empty_on_error(self, poller: TelegramBotPoller) -> None:
+        target = "qracer.notifications.telegram_poller.urllib.request.urlopen"
+        with patch(target, side_effect=urllib.error.URLError("offline")):
+            commands, messages = await poller.poll_all()
+
+        assert commands == []
+        assert messages == []
+
+    async def test_poll_still_returns_only_commands(
+        self, poller: TelegramBotPoller
+    ) -> None:
+        payload = {
+            "ok": True,
+            "result": [
+                _make_update(10, 999, "/status"),
+                _make_update(11, 999, "free text query"),
+            ],
+        }
+        target = "qracer.notifications.telegram_poller.urllib.request.urlopen"
+        with patch(target, return_value=_mock_response(payload)):
+            commands = await poller.poll()
+
+        assert len(commands) == 1
+        assert commands[0].action == "status"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from qracer.alerts import Alert, AlertCondition
-from qracer.notifications.telegram_poller import BotCommand
+from qracer.notifications.telegram_poller import BotCommand, BotMessage
 from qracer.server import Server, _format_duration
 from qracer.tasks import Task, TaskActionType, TaskScheduleType, TaskStatus
 
@@ -528,6 +528,170 @@ class TestBotCommandHandlers:
             TaskActionType.ANALYZE, {"ticker": "AAPL"}, "every 1h"
         )
         assert "Scheduled task nn" in out
+
+
+class TestServerConversationRouting:
+    """Telegram free-text → ConversationEngine → reply."""
+
+    @staticmethod
+    def _engine_mock(response_text: str = "Analysis complete.") -> MagicMock:
+        engine = MagicMock()
+        resp = MagicMock()
+        resp.text = response_text
+        engine.query = AsyncMock(return_value=resp)
+        return engine
+
+    async def test_free_text_routed_to_engine(self) -> None:
+        monitor = _make_monitor()
+        executor = _make_executor()
+        poller = _make_poller()
+        engine = self._engine_mock("AAPL looks bullish.")
+
+        poller.poll_all = AsyncMock(
+            return_value=([], [BotMessage(text="What about AAPL?")])
+        )
+
+        server = Server(
+            monitor, executor, telegram_poller=poller, conversation_engine=engine
+        )
+        await server._tick()
+
+        engine.query.assert_awaited_once_with("What about AAPL?")
+        assert poller.send_reply.await_count == 2
+        assert poller.send_reply.await_args_list[0][0][0] == "Analyzing your query..."
+        assert "AAPL looks bullish." in poller.send_reply.await_args_list[1][0][0]
+
+    async def test_commands_still_dispatched_with_engine(self) -> None:
+        monitor = _make_monitor()
+        monitor.store.get_active.return_value = []
+        executor = _make_executor()
+        poller = _make_poller()
+        engine = self._engine_mock()
+
+        poller.poll_all = AsyncMock(
+            return_value=(
+                [BotCommand(action="alerts", args=[], raw_text="/alerts")],
+                [],
+            )
+        )
+
+        server = Server(
+            monitor, executor, telegram_poller=poller, conversation_engine=engine
+        )
+        await server._tick()
+
+        engine.query.assert_not_awaited()
+        poller.send_reply.assert_awaited_once()
+        assert "No active alerts" in poller.send_reply.await_args[0][0]
+
+    async def test_engine_error_sends_failure_reply(self) -> None:
+        monitor = _make_monitor()
+        executor = _make_executor()
+        poller = _make_poller()
+        engine = self._engine_mock()
+        engine.query = AsyncMock(side_effect=RuntimeError("LLM timeout"))
+
+        poller.poll_all = AsyncMock(
+            return_value=([], [BotMessage(text="analyze TSLA")])
+        )
+
+        server = Server(
+            monitor, executor, telegram_poller=poller, conversation_engine=engine
+        )
+        await server._tick()
+
+        assert poller.send_reply.await_count == 2
+        error_reply = poller.send_reply.await_args_list[1][0][0]
+        assert "Query failed" in error_reply
+        assert "LLM timeout" in error_reply
+
+    async def test_empty_message_ignored(self) -> None:
+        monitor = _make_monitor()
+        executor = _make_executor()
+        poller = _make_poller()
+        engine = self._engine_mock()
+
+        poller.poll_all = AsyncMock(return_value=([], [BotMessage(text="")]))
+
+        server = Server(
+            monitor, executor, telegram_poller=poller, conversation_engine=engine
+        )
+        await server._tick()
+
+        engine.query.assert_not_awaited()
+        poller.send_reply.assert_not_called()
+
+    async def test_no_engine_uses_poll_not_poll_all(self) -> None:
+        monitor = _make_monitor()
+        executor = _make_executor()
+        poller = _make_poller()
+        poller.poll_all = AsyncMock()
+
+        server = Server(monitor, executor, telegram_poller=poller)
+        await server._tick()
+
+        poller.poll.assert_awaited_once()
+        poller.poll_all.assert_not_awaited()
+
+    async def test_with_engine_uses_poll_all(self) -> None:
+        monitor = _make_monitor()
+        executor = _make_executor()
+        poller = _make_poller()
+        engine = self._engine_mock()
+
+        poller.poll_all = AsyncMock(return_value=([], []))
+
+        server = Server(
+            monitor, executor, telegram_poller=poller, conversation_engine=engine
+        )
+        await server._tick()
+
+        poller.poll_all.assert_awaited_once()
+        poller.poll.assert_not_awaited()
+
+    async def test_mixed_commands_and_messages(self) -> None:
+        monitor = _make_monitor()
+        monitor.store.get_active.return_value = []
+        executor = _make_executor()
+        poller = _make_poller()
+        engine = self._engine_mock("Here is the analysis.")
+
+        poller.poll_all = AsyncMock(
+            return_value=(
+                [BotCommand(action="alerts", args=[], raw_text="/alerts")],
+                [BotMessage(text="Analyze NVDA")],
+            )
+        )
+
+        server = Server(
+            monitor, executor, telegram_poller=poller, conversation_engine=engine
+        )
+        await server._tick()
+
+        engine.query.assert_awaited_once_with("Analyze NVDA")
+        assert poller.send_reply.await_count == 3
+        replies = [call[0][0] for call in poller.send_reply.await_args_list]
+        assert "No active alerts" in replies[0]
+        assert replies[1] == "Analyzing your query..."
+        assert "Here is the analysis." in replies[2]
+
+
+class TestBotCommandHandlerConversationHelp:
+    def test_help_includes_query_hint_when_engine_enabled(self) -> None:
+        monitor = _make_monitor()
+        executor = _make_executor()
+        server = Server(
+            monitor, executor, conversation_engine=MagicMock()
+        )
+        out = server._dispatch_bot_command(BotCommand("help", [], "/help"))
+        assert "question directly" in out.lower() or "without a /" in out
+
+    def test_help_omits_query_hint_without_engine(self) -> None:
+        monitor = _make_monitor()
+        executor = _make_executor()
+        server = Server(monitor, executor)
+        out = server._dispatch_bot_command(BotCommand("help", [], "/help"))
+        assert "without a /" not in out
 
 
 class TestFormatDuration:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -547,13 +547,9 @@ class TestServerConversationRouting:
         poller = _make_poller()
         engine = self._engine_mock("AAPL looks bullish.")
 
-        poller.poll_all = AsyncMock(
-            return_value=([], [BotMessage(text="What about AAPL?")])
-        )
+        poller.poll_all = AsyncMock(return_value=([], [BotMessage(text="What about AAPL?")]))
 
-        server = Server(
-            monitor, executor, telegram_poller=poller, conversation_engine=engine
-        )
+        server = Server(monitor, executor, telegram_poller=poller, conversation_engine=engine)
         await server._tick()
 
         engine.query.assert_awaited_once_with("What about AAPL?")
@@ -575,9 +571,7 @@ class TestServerConversationRouting:
             )
         )
 
-        server = Server(
-            monitor, executor, telegram_poller=poller, conversation_engine=engine
-        )
+        server = Server(monitor, executor, telegram_poller=poller, conversation_engine=engine)
         await server._tick()
 
         engine.query.assert_not_awaited()
@@ -591,13 +585,9 @@ class TestServerConversationRouting:
         engine = self._engine_mock()
         engine.query = AsyncMock(side_effect=RuntimeError("LLM timeout"))
 
-        poller.poll_all = AsyncMock(
-            return_value=([], [BotMessage(text="analyze TSLA")])
-        )
+        poller.poll_all = AsyncMock(return_value=([], [BotMessage(text="analyze TSLA")]))
 
-        server = Server(
-            monitor, executor, telegram_poller=poller, conversation_engine=engine
-        )
+        server = Server(monitor, executor, telegram_poller=poller, conversation_engine=engine)
         await server._tick()
 
         assert poller.send_reply.await_count == 2
@@ -613,9 +603,7 @@ class TestServerConversationRouting:
 
         poller.poll_all = AsyncMock(return_value=([], [BotMessage(text="")]))
 
-        server = Server(
-            monitor, executor, telegram_poller=poller, conversation_engine=engine
-        )
+        server = Server(monitor, executor, telegram_poller=poller, conversation_engine=engine)
         await server._tick()
 
         engine.query.assert_not_awaited()
@@ -641,9 +629,7 @@ class TestServerConversationRouting:
 
         poller.poll_all = AsyncMock(return_value=([], []))
 
-        server = Server(
-            monitor, executor, telegram_poller=poller, conversation_engine=engine
-        )
+        server = Server(monitor, executor, telegram_poller=poller, conversation_engine=engine)
         await server._tick()
 
         poller.poll_all.assert_awaited_once()
@@ -663,9 +649,7 @@ class TestServerConversationRouting:
             )
         )
 
-        server = Server(
-            monitor, executor, telegram_poller=poller, conversation_engine=engine
-        )
+        server = Server(monitor, executor, telegram_poller=poller, conversation_engine=engine)
         await server._tick()
 
         engine.query.assert_awaited_once_with("Analyze NVDA")
@@ -680,9 +664,7 @@ class TestBotCommandHandlerConversationHelp:
     def test_help_includes_query_hint_when_engine_enabled(self) -> None:
         monitor = _make_monitor()
         executor = _make_executor()
-        server = Server(
-            monitor, executor, conversation_engine=MagicMock()
-        )
+        server = Server(monitor, executor, conversation_engine=MagicMock())
         out = server._dispatch_bot_command(BotCommand("help", [], "/help"))
         assert "question directly" in out.lower() or "without a /" in out
 


### PR DESCRIPTION
## Summary

Addresses part of #165.

PR #173 added `/briefing`, `/watchlist`, `/thesis` bot commands and multi-chat auth, but explicitly deferred the core conversational query routing: "Route incoming Telegram messages to `ConversationEngine.query()` — needs `ConversationEngine` wired into `serve`." This PR closes that gap.

Users can now type any natural-language question directly in the Telegram chat (without a `/` prefix) and receive an AI-powered analysis response — the same full pipeline (intent parsing → data fetching → analysis → synthesis) that the REPL provides.

## What changed

- **`qracer/notifications/telegram_poller.py`**
  - New `BotMessage` frozen dataclass for free-text (non-command) messages.
  - Refactored `_poll_sync` into `_fetch_updates() -> tuple[list[BotCommand], list[BotMessage]]` — shared core that separates `/commands` from free-text, strips whitespace, and skips blank messages.
  - `poll()` unchanged (backward compatible, still returns `list[BotCommand]`).
  - New `poll_all()` async method — returns both commands and free-text messages.

- **`qracer/server.py`**
  - `Server.__init__` accepts optional `conversation_engine: ConversationEngine`.
  - `_tick()` uses `poll_all()` when engine is available, `poll()` otherwise — no behavior change for servers without an engine.
  - New `_handle_bot_message(message: BotMessage)` — sends "Analyzing your query..." indicator, runs `engine.query(text)`, and replies with the response. Errors are caught and surfaced as a failure reply.
  - Passes `conversation_enabled` flag to `BotCommandHandler` for help text.

- **`qracer/notifications/bot_commands.py`**
  - `BotCommandHandler.__init__` accepts `conversation_enabled: bool` kwarg.
  - `/help` text dynamically includes "type any question directly (without a /)" hint when the engine is wired.

- **`qracer/cli.py` (`serve` command)**
  - When `telegram_poller` is configured, builds a full `ConversationEngine` with `SessionLogger`, `MemorySearcher`, `FactStore`, `summaries_dir`, `context_path`, and `report_dir` — mirroring the REPL's setup.
  - Passes the engine into `Server(conversation_engine=...)`.
  - Startup banner shows "commands + conversational queries" when engine is active.

## Scope mapping (#165)

| Scope item | Status |
|---|---|
| Wire `TelegramBotPoller` into `qracer serve` event loop | ✅ already in place |
| Route incoming Telegram messages to `ConversationEngine.query()` | ✅ **new in this PR** |
| Send autonomous monitoring alerts via Telegram | ✅ already flows through `NotificationRegistry` |
| `/briefing`, `/watchlist`, `/thesis` commands | ✅ covered by PR #173 |
| `telegram.bot_token` config | ✅ already in place |
| Rate limiting and error handling | ✅ already in place |

## Test plan

- `uv run pytest tests/notifications/test_telegram_poller.py tests/test_server.py` — **93 passed** (17 new tests).
- `uv run pytest` full suite — **1076 passed, 16 skipped** (0 regressions).
- `uv run ruff check` on changed files — clean.
- `uv run pyright` on changed files — 0 errors.

### New test coverage

**`tests/notifications/test_telegram_poller.py`** (8 new)
- `BotMessage`: frozen dataclass, equality.
- `poll_all()`: returns both commands and messages from a mixed update batch; strips whitespace from messages; skips whitespace-only messages; filters unauthorised chats; returns empty tuples on network error; `poll()` backward compat still returns only commands.

**`tests/test_server.py`** (9 new)
- Free-text message routed to `engine.query()` with "Analyzing..." indicator sent first.
- Commands still dispatched normally when engine is present.
- Engine exception sends a failure reply to the chat.
- Empty messages ignored (no engine call, no reply).
- Without engine: uses `poll()`, not `poll_all()`.
- With engine: uses `poll_all()`, not `poll()`.
- Mixed commands + messages in one tick: both processed correctly.
- Help text includes query hint when engine enabled, omits it otherwise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Em5bz5GbST6Qec5VuEofsj)_